### PR TITLE
[GWL-7] Network 라이브러리 구현

### DIFF
--- a/iOS/Projects/App/Project.swift
+++ b/iOS/Projects/App/Project.swift
@@ -12,10 +12,8 @@ let project = Project.makeModule(
   name: "WeTri",
   product: .app,
   dependencies: [
-    .project(
-      target: "DesignSystem",
-      path: .relativeToRoot("Projects/Shared/DesignSystem")
-    ),
+    ProjectTargetDependency.DesignSystem,
+    ProjectTargetDependency.Trinet,
   ],
   resources: ["Resources/**"],
   infoPlist: .extendingDefault(

--- a/iOS/Projects/Core/Network/Project.swift
+++ b/iOS/Projects/Core/Network/Project.swift
@@ -1,3 +1,5 @@
 import ProjectDescription
 import ProjectDescriptionHelpers
 
+/// Trinet
+let project = Project.makeModule(name: "Trinet", platform: .iOS, product: .staticLibrary, resources: nil, isTestable: true)

--- a/iOS/Projects/Core/Network/Sources/MockURLSession.swift
+++ b/iOS/Projects/Core/Network/Sources/MockURLSession.swift
@@ -1,0 +1,50 @@
+//
+//  MockURLSession.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/15/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - MockURLSession
+
+public struct MockURLSession: URLSessionProtocol {
+  let mockData: Data
+  let mockResponse: URLResponse
+  let mockError: Error?
+
+  init(mockData: Data = Data(), mockResponse: URLResponse = URLResponse(), mockError: Error? = nil) {
+    self.mockData = mockData
+    self.mockResponse = mockResponse
+    self.mockError = mockError
+  }
+
+  func data(for _: URLRequest, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+    return (mockData, mockResponse)
+  }
+
+  func dataTask(
+    with _: URLRequest,
+    completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
+  ) -> URLSessionDataTask {
+    return MockURLSessionData {
+      completionHandler(mockData, mockResponse, mockError)
+    }
+  }
+}
+
+// MARK: - MockURLSessionData
+
+final class MockURLSessionData: URLSessionDataTask {
+  private let handler: () -> Void
+
+  init(handler: @escaping () -> Void) {
+    self.handler = handler
+  }
+
+  override func resume() {
+    handler()
+  }
+}

--- a/iOS/Projects/Core/Network/Sources/MockURLSession.swift
+++ b/iOS/Projects/Core/Network/Sources/MockURLSession.swift
@@ -15,17 +15,17 @@ public struct MockURLSession: URLSessionProtocol {
   let mockResponse: URLResponse
   let mockError: Error?
 
-  init(mockData: Data = Data(), mockResponse: URLResponse = URLResponse(), mockError: Error? = nil) {
+  public init(mockData: Data = Data(), mockResponse: URLResponse = URLResponse(), mockError: Error? = nil) {
     self.mockData = mockData
     self.mockResponse = mockResponse
     self.mockError = mockError
   }
 
-  func data(for _: URLRequest, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
+  public func data(for _: URLRequest, delegate _: URLSessionTaskDelegate?) async throws -> (Data, URLResponse) {
     return (mockData, mockResponse)
   }
 
-  func dataTask(
+  public func dataTask(
     with _: URLRequest,
     completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
   ) -> URLSessionDataTask {

--- a/iOS/Projects/Core/Network/Sources/TNEndPoint.swift
+++ b/iOS/Projects/Core/Network/Sources/TNEndPoint.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+// MARK: - TNEndPoint
+
 public protocol TNEndPoint {
   var baseURL: String { get }
   var path: String { get }
@@ -15,4 +17,50 @@ public protocol TNEndPoint {
   var query: Encodable? { get }
   var body: Encodable? { get }
   var headers: TNHeaders { get }
+}
+
+public extension TNEndPoint {
+  func request() throws -> URLRequest {
+    guard let targetURL = URL(string: baseURL)?.appending(path: path).appending(query: query)
+    else {
+      throw TNError.invalidURL
+    }
+    var request = URLRequest(url: targetURL)
+    request.httpMethod = method.rawValue
+    request.allHTTPHeaderFields = headers.dictionary
+    request.httpBody = body?.data
+
+    return request
+  }
+}
+
+private extension URL {
+  func appending(query: Encodable?) -> URL? {
+    guard let query else {
+      return self
+    }
+    var urlComponents = URLComponents(string: absoluteString)
+    urlComponents?.queryItems = query.dictionary.map { (key: String, value: Any) in
+      return URLQueryItem(name: key, value: "\(value)")
+    }
+    return urlComponents?.url
+  }
+}
+
+private extension Encodable {
+  var data: Data? {
+    return try? JSONEncoder().encode(self)
+  }
+
+  var dictionary: [String: Any] {
+    guard
+      let data = try? JSONEncoder().encode(self),
+      let jsonData = try? JSONSerialization.jsonObject(with: data),
+      let dictionaryTarget = jsonData as? [String: Any]
+    else {
+      return [:]
+    }
+
+    return dictionaryTarget
+  }
 }

--- a/iOS/Projects/Core/Network/Sources/TNEndPoint.swift
+++ b/iOS/Projects/Core/Network/Sources/TNEndPoint.swift
@@ -1,0 +1,18 @@
+//
+//  TNEndPoint.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/14/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+public protocol TNEndPoint {
+  var baseURL: String { get }
+  var path: String { get }
+  var method: TNMethod { get }
+  var query: Encodable? { get }
+  var body: Encodable? { get }
+  var headers: TNHeaders { get }
+}

--- a/iOS/Projects/Core/Network/Sources/TNError.swift
+++ b/iOS/Projects/Core/Network/Sources/TNError.swift
@@ -1,0 +1,20 @@
+//
+//  TNError.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/14/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+public enum TNError: LocalizedError {
+  case invalidURL
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidURL:
+      return "URL이 잘못되었습니다."
+    }
+  }
+}

--- a/iOS/Projects/Core/Network/Sources/TNHeader.swift
+++ b/iOS/Projects/Core/Network/Sources/TNHeader.swift
@@ -8,9 +8,13 @@
 
 import Foundation
 
-// HTTP 헤더를 나타냅니다.
-
-public struct TNHeader {
+/// HTTP 헤더를 나타냅니다.
+public struct TNHeader: Hashable {
   let key: String
   let value: String
+
+  public init(key: String, value: String) {
+    self.key = key
+    self.value = value
+  }
 }

--- a/iOS/Projects/Core/Network/Sources/TNHeader.swift
+++ b/iOS/Projects/Core/Network/Sources/TNHeader.swift
@@ -1,0 +1,16 @@
+//
+//  TNHeader.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/14/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// HTTP 헤더를 나타냅니다.
+
+public struct TNHeader {
+  let key: String
+  let value: String
+}

--- a/iOS/Projects/Core/Network/Sources/TNHeaders.swift
+++ b/iOS/Projects/Core/Network/Sources/TNHeaders.swift
@@ -1,0 +1,18 @@
+//
+//  TNHeaders.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/14/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+public struct TNHeaders {
+  var headers: [TNHeader]
+
+  var dictionary: [String: String] {
+    let headersTuple = headers.map { ($0.key, $0.value) }
+    return Dictionary(uniqueKeysWithValues: headersTuple)
+  }
+}

--- a/iOS/Projects/Core/Network/Sources/TNHeaders.swift
+++ b/iOS/Projects/Core/Network/Sources/TNHeaders.swift
@@ -8,8 +8,12 @@
 
 import Foundation
 
-public struct TNHeaders {
-  var headers: [TNHeader]
+public struct TNHeaders: Hashable {
+  private var headers: [TNHeader]
+
+  public init(headers: [TNHeader]) {
+    self.headers = headers
+  }
 
   var dictionary: [String: String] {
     let headersTuple = headers.map { ($0.key, $0.value) }

--- a/iOS/Projects/Core/Network/Sources/TNMethod.swift
+++ b/iOS/Projects/Core/Network/Sources/TNMethod.swift
@@ -1,0 +1,15 @@
+//
+//  TNMethod.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/14/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+public enum TNMethod: String {
+  case get = "GET"
+  case post = "POST"
+  case delete = "DELETE"
+}

--- a/iOS/Projects/Core/Network/Sources/TNProvidable.swift
+++ b/iOS/Projects/Core/Network/Sources/TNProvidable.swift
@@ -1,0 +1,76 @@
+//
+//  TNProvidable.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/14/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - TNProvidable
+
+protocol TNProvidable {
+  func request<EndPoint: TNEndPoint>(endpoint: EndPoint) async throws -> Data
+}
+
+// MARK: - TNProvider
+
+struct TNProvider: TNProvidable {
+  private let session: URLSession
+  init(session: URLSession) {
+    self.session = session
+  }
+
+  func request(endpoint: some TNEndPoint) async throws -> Data {
+    let (data, urlResponse) = try await session.data(for: endpoint.request())
+
+    return data
+  }
+}
+
+private extension TNEndPoint {
+  func request() throws -> URLRequest {
+    guard let targetURL = URL(string: baseURL)?.appending(path: path).appending(query: query)
+    else {
+      throw TNError.invalidURL
+    }
+    var request = URLRequest(url: targetURL)
+    request.httpMethod = method.rawValue
+    request.allHTTPHeaderFields = headers.dictionary
+    request.httpBody = body?.data
+
+    return request
+  }
+}
+
+private extension URL {
+  func appending(query: Encodable?) -> URL? {
+    guard let query else {
+      return self
+    }
+    var urlComponents = URLComponents(string: absoluteString)
+    urlComponents?.queryItems = query.dictionary.map { (key: String, value: Any) in
+      return URLQueryItem(name: key, value: "\(value)")
+    }
+    return urlComponents?.url
+  }
+}
+
+private extension Encodable {
+  var data: Data? {
+    return try? JSONEncoder().encode(self)
+  }
+
+  var dictionary: [String: Any] {
+    guard
+      let data = try? JSONEncoder().encode(self),
+      let jsonData = try? JSONSerialization.jsonObject(with: data),
+      let dictionaryTarget = jsonData as? [String: Any]
+    else {
+      return [:]
+    }
+
+    return dictionaryTarget
+  }
+}

--- a/iOS/Projects/Core/Network/Sources/TNProvidable.swift
+++ b/iOS/Projects/Core/Network/Sources/TNProvidable.swift
@@ -20,7 +20,8 @@ public protocol TNProvidable {
 
 public struct TNProvider<T: TNEndPoint>: TNProvidable {
   private let session: URLSessionProtocol
-  init(session: URLSessionProtocol) {
+
+  public init(session: URLSessionProtocol) {
     self.session = session
   }
 

--- a/iOS/Projects/Core/Network/Sources/Trinet.swift
+++ b/iOS/Projects/Core/Network/Sources/Trinet.swift
@@ -1,0 +1,10 @@
+//
+//  Trinet.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by MaraMincho on 11/14/23.
+//
+
+import Foundation
+
+final class Trinet {}

--- a/iOS/Projects/Core/Network/Sources/URLSessionProtocol.swift
+++ b/iOS/Projects/Core/Network/Sources/URLSessionProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - URLSessionProtocol
 
-protocol URLSessionProtocol {
+public protocol URLSessionProtocol {
   func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)
 
   func dataTask(

--- a/iOS/Projects/Core/Network/Sources/URLSessionProtocol.swift
+++ b/iOS/Projects/Core/Network/Sources/URLSessionProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  URLSessionProtocol.swift
+//  Trinet
+//
+//  Created by MaraMincho on 11/15/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - URLSessionProtocol
+
+protocol URLSessionProtocol {
+  func data(for request: URLRequest, delegate: URLSessionTaskDelegate?) async throws -> (Data, URLResponse)
+
+  func dataTask(
+    with request: URLRequest,
+    completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void
+  ) -> URLSessionDataTask
+}
+
+// MARK: - URLSession + URLSessionProtocol
+
+extension URLSession: URLSessionProtocol {}

--- a/iOS/Projects/Core/Network/Tests/Test.swift
+++ b/iOS/Projects/Core/Network/Tests/Test.swift
@@ -42,7 +42,7 @@ final class Test: XCTestCase {
 
     // Assert
     XCTAssertNotNil(targetURL)
-    XCTAssertEqual(targetURL, URL(string: "base"))
+    XCTAssertEqual(targetURL, URL(string: "base/"))
   }
 
   func test_Base와Path를포함_urlRequest를생성_성공() throws {

--- a/iOS/Projects/Core/Network/Tests/Test.swift
+++ b/iOS/Projects/Core/Network/Tests/Test.swift
@@ -5,4 +5,127 @@
 //  Created by MaraMincho on 11/14/23.
 //
 
+@testable import Trinet
 import XCTest
+
+final class Test: XCTestCase {
+  struct TestEndPoint: TNEndPoint {
+    var baseURL: String = "base"
+    var path: String = "path"
+    var method: TNMethod = .get
+    var query: Encodable? = nil
+    var body: Encodable? = nil
+    var headers: TNHeaders = .init(headers: [
+      .init(key: "First", value: "First"),
+    ])
+  }
+
+  var sut: TNEndPoint! = nil
+
+  let provider = TNProvider<TestEndPoint>(session: URLSession.shared)
+
+  func temp() async throws {}
+
+  override func setUp() {
+    sut = TestEndPoint()
+  }
+
+  override func tearDown() {
+    sut = nil
+  }
+
+  func test_Base포함Path미포함_urlRequest를생성_URL확인() throws {
+    sut = TestEndPoint(baseURL: "base", path: "")
+
+    // Act
+    let targetURL = try sut.request().url
+
+    // Assert
+    XCTAssertNotNil(targetURL)
+    XCTAssertEqual(targetURL, URL(string: "base"))
+  }
+
+  func test_Base와Path를포함_urlRequest를생성_성공() throws {
+    // Act
+    let targetURL = try sut.request().url
+
+    // Assert
+    XCTAssertNotNil(targetURL)
+    XCTAssertEqual(targetURL, URL(string: "base/path"))
+  }
+
+  func test_Query() throws {
+    sut = TestEndPoint(query: ["Some": "Time"])
+    // Act
+    let targetURL = try sut.request().url
+
+    // Assert
+    XCTAssertNotNil(targetURL)
+    XCTAssertEqual(targetURL, URL(string: "base/path?Some=Time"))
+  }
+
+  func test_QueryIntValue() throws {
+    sut = TestEndPoint(query: ["Int": "3"])
+    // Act
+    let targetURL = try sut.request().url
+
+    // Assert
+    XCTAssertNotNil(targetURL)
+    XCTAssertEqual(targetURL, URL(string: "base/path?Int=3"))
+  }
+
+  func test_Body에String을넣고생성하고_request를생성했을때_body값이주입한String과똑같다() throws {
+    let bodyString = "바디 스트링"
+    sut = TestEndPoint(body: bodyString)
+
+    let body = try sut.request().httpBody!
+
+    XCTAssertEqual(bodyString, try JSONDecoder().decode(String.self, from: body))
+  }
+
+  func test_Body에nil을넣고_request를생성했을때_body의값이nil이적재된다() throws {
+    sut = TestEndPoint(body: nil)
+
+    let body = try sut.request().httpBody
+
+    XCTAssertNil(body)
+  }
+
+  func test_HTTPHeader에값을넣고_request을생성하면_넣은Header값과똑같다() throws {
+    let headers: TNHeaders = .init(headers: [
+      .init(key: "Header", value: "1"),
+      .init(key: "Headerable", value: "2"),
+    ])
+
+    sut = TestEndPoint(headers: headers)
+    let requestHeader = try sut.request().allHTTPHeaderFields
+    XCTAssertEqual(headers.dictionary, requestHeader)
+  }
+
+  func test_Mock확인() throws {
+    let testData = "hihi".data(using: .utf8)!
+    let mockSession = MockURLSession(mockData: testData)
+    let provider = TNProvider<TestEndPoint>(session: mockSession)
+    let targetSut = TestEndPoint()
+
+    let expectation = XCTestExpectation(description: "API호출 완료 Expectaion")
+    var providedData = Data()
+    try provider.request(targetSut) { data, _, _ in
+      providedData = data ?? providedData
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 3)
+
+    XCTAssertEqual(testData, providedData)
+  }
+
+  func test_Mock확인2() async throws {
+    let testData = "안녕하세요".data(using: .utf8)!
+    let mockSession = MockURLSession(mockData: testData)
+    let provider = TNProvider<TestEndPoint>(session: mockSession)
+    let targetSut = TestEndPoint()
+    let provideData = try await provider.request(targetSut)
+
+    XCTAssertEqual(testData, provideData)
+  }
+}

--- a/iOS/Projects/Core/Network/Tests/Test.swift
+++ b/iOS/Projects/Core/Network/Tests/Test.swift
@@ -1,0 +1,8 @@
+//
+//  Test.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by MaraMincho on 11/14/23.
+//
+
+import XCTest

--- a/iOS/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
@@ -1,0 +1,13 @@
+//
+//  TargetDependency.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by MaraMincho on 11/14/23.
+//
+
+import ProjectDescription
+
+public enum ProjectTargetDependency {
+  public static let DesignSystem: TargetDependency = .project(target: "DesignSystem", path: .relativeToRoot("Projects/Shared/DesignSystem"))
+  public static let Trinet: TargetDependency = .project(target: "Trinet", path: .relativeToRoot("Projects/Core/Network"))
+}


### PR DESCRIPTION
## Screenshots 📸

|Trinet Coverage 91%|
|:-:|
|<img width="1426" alt="image" src="https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/e31f9fbd-8843-4a03-91d7-c1ec9968b404">|

<br/><br/>

## 고민, 과정, 근거 💬

### Provider의 리턴타입을 왜 Data로 두었는가

- 서버와 서로 API 구조를 논의하지 않았으므로 협의 필요

### Mock 작성<sup>[[1]](#ref1)</sup>
- URLSessionProtocol 생성
- async 와 관련된 Mock
- Completion과 관련된 Mock

### 파일 분리
- 기존 Provider쪽에 있던 endpoint의 request를 endpoint 파일로 옮김

<br/><br/>

## References 📋

1. <a id="ref1">[[Swift] Mock 을 이용한 Network Unit Test 하기](https://sujinnaljin.medium.com/swift-mock-을-이용한-network-unit-test-하기-a69570defb41)</a>
2. [Moya/Moya: Network abstraction layer written in Swift](https://github.com/Moya/Moya)

<br/><br/>

---

- Closed: #30 
