### PR TITLE
[GWL-41] TNCombineCococa 구현 

### DIFF
--- a/iOS/Projects/Features/Record/Project.swift
+++ b/iOS/Projects/Features/Record/Project.swift
@@ -8,6 +8,7 @@ let project = Project.makeModule(
   dependencies: [
     ProjectTargetDependency.Trinet,
     ProjectTargetDependency.DesignSystem,
+    ProjectTargetDependency.TNCocoaCombine,
   ],
   isTestable: true
 )

--- a/iOS/Projects/Shared/TNCocoaCombine/Project.swift
+++ b/iOS/Projects/Shared/TNCocoaCombine/Project.swift
@@ -1,0 +1,8 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+  name: "TNCocoaCombine",
+  product: .framework,
+  isTestable: false
+)

--- a/iOS/Projects/Shared/TNCocoaCombine/Sources/EventSubscription.swift
+++ b/iOS/Projects/Shared/TNCocoaCombine/Sources/EventSubscription.swift
@@ -1,0 +1,36 @@
+//
+//  EventSubscription.swift
+//  TNCocoaCombine
+//
+//  Created by MaraMincho on 11/15/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+class EventSubscription<EventSubscriber: Subscriber>:
+  Subscription where EventSubscriber.Input == UIControl, EventSubscriber.Failure == Never {
+  func request(_: Subscribers.Demand) {}
+
+  func cancel() {
+    subscriber = nil
+    control.removeTarget(self, action: #selector(eventDidOccur), for: event)
+  }
+
+  @objc func eventDidOccur() {
+    _ = subscriber?.receive(control)
+  }
+
+  let control: UIControl
+  let event: UIControl.Event
+  var subscriber: EventSubscriber?
+
+  init(control: UIControl, event: UIControl.Event, subscriber: EventSubscriber) {
+    self.control = control
+    self.event = event
+    self.subscriber = subscriber
+
+    control.addTarget(self, action: #selector(eventDidOccur), for: event)
+  }
+}

--- a/iOS/Projects/Shared/TNCocoaCombine/Sources/UIControl+Publisher.swift
+++ b/iOS/Projects/Shared/TNCocoaCombine/Sources/UIControl+Publisher.swift
@@ -1,0 +1,29 @@
+//
+//  UIControl+Publisher.swift
+//  TNCocoaCombine
+//
+//  Created by MaraMincho on 11/15/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+public extension UIControl {
+  func publisher(_ event: UIControl.Event) -> EventPublisher {
+    return EventPublisher(control: self, event: event)
+  }
+
+  struct EventPublisher: Publisher {
+    public typealias Output = UIControl
+    public typealias Failure = Never
+
+    let control: UIControl
+    let event: UIControl.Event
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, UIControl == S.Input {
+      let subscription = EventSubscription(control: control, event: event, subscriber: subscriber)
+      subscriber.receive(subscription: subscription)
+    }
+  }
+}

--- a/iOS/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/TargetDependency.swift
@@ -11,4 +11,5 @@ public enum ProjectTargetDependency {
   public static let DesignSystem: TargetDependency = .project(target: "DesignSystem", path: .relativeToRoot("Projects/Shared/DesignSystem"))
   public static let Trinet: TargetDependency = .project(target: "Trinet", path: .relativeToRoot("Projects/Core/Network"))
   public static let Record: TargetDependency = .project(target: "RecordFeature", path: .relativeToRoot("Projects/Features/Record"))
+  public static let TNCocoaCombine: TargetDependency = .project(target: "TNCocoaCombine", path: .relativeToRoot("Projects/Shared/TNCocoaCombine"))
 }


### PR DESCRIPTION
## 고민, 과정, 근거 💬

### 해결 내용

- UIControl의 객체를 Event를 Publisher하는 객체로 어떻게 만들까에 대한 고민 (combine을 활용한)
- [TNCombineCocoa를 직접 구현](https://www.notion.so/geul-woll/TNCocoaCombine-4d8dd06e1690442eae57d6bcfe6ce0db?d=23eb62c1fcda4feb90c1a1325f80b238#559890e01bd94ea8a29d06c13554482b)

### 향후 과제
- UIView에 적용 가능한 UITapGesture또한 확장 가능
- 작성한 코드를 어떤 식으로 테스트 할지 결정
  - 현재는 테스트코드 작성 불가


<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #40 
