### PR TITLE
[GWL-54] Tuist Test Github Action 적용

### DIFF
--- a/.github/workflows/iOS_CI.yml
+++ b/.github/workflows/iOS_CI.yml
@@ -1,0 +1,36 @@
+name: iOS-CI
+
+on:
+  push:
+    branches: 'feature/iOS/*'
+  pull_request:
+    branches: 'develop'
+    types: [labeled, opened, synchronize, reopened]
+
+jobs:
+  tuist-test:
+    if: contains(github.event.pull_request.labels.*.name, '📱 iOS')
+    runs-on: macos-13
+    env:
+      working-directory: ./iOS
+
+    steps:
+      - name: Xcode Version Settings
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "15.0.1"
+
+      - name: Code Checkout
+      - uses: actions/checkout@v3
+
+      - name: Install Tuist
+        run: brew install tuist
+        working-directory: ${{env.working-directory}}
+
+      - name: Print Tuist Version
+        run: tuist version
+        working-directory: ${{env.working-directory}}
+
+      - name: Run Tuist Test
+        run: make test
+        working-directory: ${{env.working-directory}}

--- a/iOS/Projects/Features/Record/Tests/RecordFeatureTests.swift
+++ b/iOS/Projects/Features/Record/Tests/RecordFeatureTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class RecordFeatureTests: XCTestCase {
+  func testAlwaysPassed() {
+    XCTAssertTrue(true)
+  }
+}


### PR DESCRIPTION
## Screenshots 📸

|테스트해온 과정|터미널로 동작시킨 make test|
|:-:|:-:|
|<img width="861" alt="image" src="https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/4f23a99f-7bf2-4b0b-a6cb-b5293423815a">|![Screen Recording 2023-11-18 at 6 34 54 PM](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/43eb3e94-2776-4fe0-82fe-7bdd6a0c806a)|

<br/><br/>

## 고민, 과정, 근거 💬

### 왜 Github Action을 도입해요?

Pull Request를 올릴 때 리뷰어끼리 코드를 파악하고 리뷰를 다는 방식으로 merge를 진행해왔지만, 가끔씩 파일을 다른 폴더에 두었다든지, 알고보니 에러가 내제된 코드였다든지, 그 밖의 여러 상황에 의해 다시 수정작업한 PR을 올리고는 합니다.

저희는 이러한 리소스를 사전에 방지하고자 테스트 코드를 만들고 수행하여 정상적인 코드인지를 판단하는 작업을 진행했습니다. 하지만, 이것 역시 Xcode 내에서 리뷰어마다 일일히 테스트코드를 동작시킬 수는 없는 노릇입니다.

그래서 GIthub Action을 이용해서 Pull Request가 올라올 때마다 test code를 자동으로 실행시켜주는 플로우를 만들기로 결심했습니다.

### 겪었던 고난들

#### 1. Assets Color에러

`Xcode 15.0.1`을 쓰고 있는 저희 프로젝트에서는 Resource(e.g. Assets)에 등록되어있는 색상을 자동으로 Xcode가 생성해주지만, `macos-latest` 의 최대 버전은 `Xcode 14`였습니다.<sup>[[1]](#ref1)</sup>
그래서 ~~1년째 beta버전인~~ `macos-13`을 사용해서 `Xcode 15.0.1`로 테스트하도록 수정했습니다.<sup>[[2]](#ref2)</sup><sup>[[3]](#ref3)</sup>

|Asset 인식 에러|
|:-:|
|<img src="https://file.notion.so/f/f/c31c4c67-9570-4e4c-9747-ddf9fe1f0ffc/9fb8078b-8095-471f-ba6f-3b61529dfaa4/Untitled.png?id=6f16de23-9917-45e0-9cda-6a4bcb52ccae&table=block&spaceId=c31c4c67-9570-4e4c-9747-ddf9fe1f0ffc&expirationTimestamp=1700388000000&signature=3rdZgJKXznrbonbvlqS3JtSU24NgMZ2HJV9nd-kF9bg&downloadName=Untitled.png" width="50%"/>|

#### 2. xcodebuild 65 Error

인터넷에서도 나오지 않았던 문제였는데요.. 시행착오 끝에 발견했습니다. 저희가 Feature모듈에서 Tests타겟을 등록시켰는데, test코드가 존재하지 않아 발생한 문제였습니다..!
그래서 항상 통과할 수 있는 테스트 코드를 하나 생성해두어 RecordFeature에서 Tests를 인식하도록 처리해두었습니다.<sup>[[5]](#ref5)</sup>

<br/><br/>

## References 📋

1. <a id="ref1">[runner-images](https://github.com/actions/runner-images)</a>
2. <a id="ref2">[macos-13 images](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md)</a>
3. <a id="ref3">[setup-xcode actions](https://github.com/maxim-lobanov/setup-xcode)</a>
4. <a id="ref4">[working-directory invalid 수정 · WhiteHyun/GithubActionPractice@22468b2](https://github.com/WhiteHyun/GithubActionPractice/actions/runs/6912995841/job/18809376115)</a>
5. <a id="ref5">[Github Action으로 tuist test 실행하기 - 글월팀](https://www.notion.so/geul-woll/Github-Action-tuist-test-6af479e56f3b4b808bbf064d3d051826?pvs=4)</a>

---

- Closed: #62
