### PR TITLE
[GWL-25] 지도 화면 UI 구현

### DIFF
--- a/iOS/Projects/App/WeTri/Project.swift
+++ b/iOS/Projects/App/WeTri/Project.swift
@@ -17,6 +17,11 @@ let projects = Project.makeModule(
     dependencies: [
       .coordinator,
       .feature(.record),
+    ],
+    infoPlist: [
+      "NSLocationAlwaysUsageDescription": "운동 경로를 보여줄 때 사용합니다",
+      "NSLocationAlwaysAndWhenInUseUsageDescription": "운동 경로를 보여줄 때 사용합니다",
+      "NSLocationWhenInUseUsageDescription": "운동 경로를 보여줄 때 사용합니다",
     ]
   )
 )

--- a/iOS/Projects/Features/Record/Project.swift
+++ b/iOS/Projects/Features/Record/Project.swift
@@ -7,7 +7,7 @@ let project = Project.makeModule(
   targets: .feature(
     .record,
     testingOptions: [.unitTest],
-    dependencies: [.trinet, .designSystem, .combineCocoa],
+    dependencies: [.trinet, .designSystem, .combineCocoa, .coordinator],
     testDependencies: [.trinet, .designSystem, .combineCocoa]
   )
 )

--- a/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutCoordinator.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutCoordinator.swift
@@ -24,8 +24,8 @@ final class WorkoutCoordinator: WorkoutCoordinating {
   }
 
   func pushWorkoutSummaryViewController() {
-    let workoutSummaryViewController = WorkoutSummaryViewController(
-      viewModel: WorkoutSummaryViewModel()
+    let workoutSummaryViewController = WorkoutSessionViewController(
+      viewModel: WorkoutSessionViewModel()
     )
     navigationController.pushViewController(workoutSummaryViewController, animated: false)
   }

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
@@ -1,0 +1,144 @@
+//
+//  WorkoutRouteMapViewController.swift
+//  RecordFeature
+//
+//  Created by 홍승현 on 11/21/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import CoreLocation
+import DesignSystem
+import MapKit
+import OSLog
+import UIKit
+
+// MARK: - WorkoutRouteMapViewController
+
+final class WorkoutRouteMapViewController: UIViewController {
+  // MARK: Properties
+
+  private let viewModel: WorkoutRouteMapViewModelRepresentable
+
+  private var subscriptions: Set<AnyCancellable> = []
+
+  private lazy var locationManager: CLLocationManager = {
+    let locationManager = CLLocationManager()
+    locationManager.delegate = self
+    return locationManager
+  }()
+
+  // MARK: UI Components
+
+  private let mapView: MKMapView = {
+    let mapView = MKMapView()
+    mapView.showsUserLocation = true
+    mapView.setUserTrackingMode(.follow, animated: true)
+    return mapView
+  }()
+
+  // MARK: Initializations
+
+  init(viewModel: WorkoutRouteMapViewModelRepresentable) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  deinit {
+    locationManager.stopUpdatingLocation()
+  }
+
+  // MARK: Life Cycles
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupLayouts()
+    setupConstraints()
+    setupStyles()
+    bind()
+    setupLocationManager()
+  }
+
+  // MARK: Configuration
+
+  private func setupLayouts() {
+    view.addSubview(mapView)
+  }
+
+  private func setupConstraints() {
+    let safeArea = view.safeAreaLayoutGuide
+    mapView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        mapView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+        mapView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+        mapView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.horizontal),
+        mapView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.horizontal),
+      ]
+    )
+  }
+
+  private func setupStyles() {
+    view.backgroundColor = DesignSystemColor.primaryBackground
+  }
+
+  private func bind() {
+    let output = viewModel.transform(input: .init())
+    output.sink { state in
+      switch state {
+      case .idle:
+        break
+      }
+    }
+    .store(in: &subscriptions)
+  }
+
+  private func setupLocationManager() {
+    Logger().debug("\(#function)")
+    locationManager.requestWhenInUseAuthorization()
+    locationManager.startUpdatingLocation()
+    locationManager.startMonitoringSignificantLocationChanges()
+  }
+}
+
+// MARK: CLLocationManagerDelegate
+
+extension WorkoutRouteMapViewController: CLLocationManagerDelegate {
+  func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    guard
+      manager.authorizationStatus == .authorizedWhenInUse
+      || manager.authorizationStatus == .authorizedAlways
+    else {
+      Logger().error("유저의 위치를 받아올 수 없습니다.")
+      return
+    }
+    locationManager.startUpdatingLocation()
+  }
+
+  func locationManager(_: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    Logger().debug("\(locations)")
+  }
+
+  func locationManager(_: CLLocationManager, didFailWithError error: Error) {
+    Logger().error("\(error)")
+  }
+}
+
+// MARK: WorkoutRouteMapViewController.Metrics
+
+private extension WorkoutRouteMapViewController {
+  enum Metrics {
+    static let horizontal: CGFloat = 24
+  }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, xrOS 1.0, *)
+#Preview {
+  WorkoutRouteMapViewController(viewModel: WorkoutRouteMapViewModel())
+}

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  WorkoutRouteMapViewModel.swift
+//  RecordFeature
+//
+//  Created by 홍승현 on 11/21/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+// MARK: - WorkoutRouteMapViewModelInput
+
+public struct WorkoutRouteMapViewModelInput {}
+
+public typealias WorkoutRouteMapViewModelOutput = AnyPublisher<WorkoutRouteMapState, Never>
+
+// MARK: - WorkoutRouteMapState
+
+public enum WorkoutRouteMapState {
+  case idle
+}
+
+// MARK: - WorkoutRouteMapViewModelRepresentable
+
+protocol WorkoutRouteMapViewModelRepresentable {
+  func transform(input: WorkoutRouteMapViewModelInput) -> WorkoutRouteMapViewModelOutput
+}
+
+// MARK: - WorkoutRouteMapViewModel
+
+final class WorkoutRouteMapViewModel {
+  // MARK: - Properties
+
+  private var subscriptions: Set<AnyCancellable> = []
+}
+
+// MARK: WorkoutRouteMapViewModelRepresentable
+
+extension WorkoutRouteMapViewModel: WorkoutRouteMapViewModelRepresentable {
+  public func transform(input _: WorkoutRouteMapViewModelInput) -> WorkoutRouteMapViewModelOutput {
+    for subscription in subscriptions {
+      subscription.cancel()
+    }
+    subscriptions.removeAll()
+
+    let initialState: WorkoutRouteMapViewModelOutput = Just(.idle).eraseToAnyPublisher()
+
+    return initialState
+  }
+}

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/SessionParticipantCell.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/SessionParticipantCell.swift
@@ -1,5 +1,5 @@
 //
-//  ParticipantsCollectionViewCell.swift
+//  SessionParticipantCell.swift
 //  RecordFeature
 //
 //  Created by 홍승현 on 11/16/23.
@@ -9,9 +9,9 @@
 import DesignSystem
 import UIKit
 
-// MARK: - ParticipantsCollectionViewCell
+// MARK: - SessionParticipantCell
 
-final class ParticipantsCollectionViewCell: UICollectionViewCell {
+final class SessionParticipantCell: UICollectionViewCell {
   // MARK: UI Components
 
   private let profileImageView: UIImageView = {
@@ -177,9 +177,9 @@ final class ParticipantsCollectionViewCell: UICollectionViewCell {
   }
 }
 
-// MARK: ParticipantsCollectionViewCell.Metrics
+// MARK: SessionParticipantCell.Metrics
 
-private extension ParticipantsCollectionViewCell {
+private extension SessionParticipantCell {
   enum Metrics {
     static let profileImageSize: CGFloat = 64
     static let wholeStackViewEdge: CGFloat = 10

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
@@ -1,5 +1,5 @@
 //
-//  WorkoutSummaryViewController.swift
+//  WorkoutSessionViewController.swift
 //  RecordFeature
 //
 //  Created by 홍승현 on 11/16/23.
@@ -10,12 +10,12 @@ import Combine
 import DesignSystem
 import UIKit
 
-// MARK: - WorkoutSummaryViewController
+// MARK: - WorkoutSessionViewController
 
-public final class WorkoutSummaryViewController: UIViewController {
+public final class WorkoutSessionViewController: UIViewController {
   // MARK: Properties
 
-  private let viewModel: WorkoutSummaryViewModelRepresentable
+  private let viewModel: WorkoutSessionViewModelRepresentable
 
   private var participantsDataSource: ParticipantsDataSource?
 
@@ -57,7 +57,7 @@ public final class WorkoutSummaryViewController: UIViewController {
 
   // MARK: Initializations
 
-  public init(viewModel: WorkoutSummaryViewModelRepresentable) {
+  public init(viewModel: WorkoutSessionViewModelRepresentable) {
     self.viewModel = viewModel
     super.init(nibName: nil, bundle: nil)
   }
@@ -200,9 +200,9 @@ public final class WorkoutSummaryViewController: UIViewController {
   }
 }
 
-// MARK: WorkoutSummaryViewController.Metrics
+// MARK: WorkoutSessionViewController.Metrics
 
-private extension WorkoutSummaryViewController {
+private extension WorkoutSessionViewController {
   enum Metrics {
     static let recordTimerLabelTop: CGFloat = 12
     static let collectionViewTop: CGFloat = 12
@@ -218,8 +218,8 @@ private extension WorkoutSummaryViewController {
 
 // MARK: - Diffable DataSources Options
 
-private extension WorkoutSummaryViewController {
-  typealias ParticipantsCellRegistration = UICollectionView.CellRegistration<ParticipantsCollectionViewCell, Item>
+private extension WorkoutSessionViewController {
+  typealias ParticipantsCellRegistration = UICollectionView.CellRegistration<SessionParticipantCell, Item>
   typealias ParticipantsDataSource = UICollectionViewDiffableDataSource<Section, Item>
   typealias ParticipantsSnapshot = NSDiffableDataSourceSnapshot<Section, Item>
 
@@ -233,5 +233,5 @@ private extension WorkoutSummaryViewController {
 
 @available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, xrOS 1.0, *)
 #Preview {
-  WorkoutSummaryViewController(viewModel: WorkoutSummaryViewModel())
+  WorkoutSessionViewController(viewModel: WorkoutSessionViewModel())
 }

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  WorkoutSummaryViewModel.swift
+//  WorkoutSessionViewModel.swift
 //  RecordFeature
 //
 //  Created by 홍승현 on 11/16/23.
@@ -22,15 +22,15 @@ public enum WorkoutSummaryState {
   case idle
 }
 
-// MARK: - WorkoutSummaryViewModelRepresentable
+// MARK: - WorkoutSessionViewModelRepresentable
 
-public protocol WorkoutSummaryViewModelRepresentable {
+public protocol WorkoutSessionViewModelRepresentable {
   func transform(input: WorkoutSummaryViewModelInput) -> WorkoutSummaryViewModelOutput
 }
 
-// MARK: - WorkoutSummaryViewModel
+// MARK: - WorkoutSessionViewModel
 
-public final class WorkoutSummaryViewModel {
+public final class WorkoutSessionViewModel {
   // MARK: Properties
 
   private var subscriptions: Set<AnyCancellable> = []
@@ -40,9 +40,9 @@ public final class WorkoutSummaryViewModel {
   public init() {}
 }
 
-// MARK: WorkoutSummaryViewModelRepresentable
+// MARK: WorkoutSessionViewModelRepresentable
 
-extension WorkoutSummaryViewModel: WorkoutSummaryViewModelRepresentable {
+extension WorkoutSessionViewModel: WorkoutSessionViewModelRepresentable {
   public func transform(input: WorkoutSummaryViewModelInput) -> WorkoutSummaryViewModelOutput {
     for subscription in subscriptions {
       subscription.cancel()

--- a/iOS/Tuist/ProjectDescriptionHelpers/Target+Templates.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/Target+Templates.swift
@@ -29,7 +29,10 @@ public extension [Target] {
     testingOptions: Set<TestingOption> = [],
     dependencies: [TargetDependency] = [],
     testDependencies: [TargetDependency] = [],
-    infoPlist: [String: Plist.Value] = [
+    infoPlist: [String: Plist.Value] = [:]
+  ) -> [Target] {
+
+    var defaultInfoPlist: [String: Plist.Value] = [
       "UILaunchStoryboardName": "LaunchScreen",
       "UIApplicationSceneManifest": [
         "UIApplicationSupportsMultipleScenes": false,
@@ -43,7 +46,11 @@ public extension [Target] {
         ],
       ],
     ]
-  ) -> [Target] {
+
+    defaultInfoPlist.merge(infoPlist) { _, new in
+      new
+    }
+
     var targets: [Target] = [
       Target(
         name: name,
@@ -51,7 +58,7 @@ public extension [Target] {
         product: .app,
         bundleId: "\(ProjectEnvironment.default.prefixBundleID).\(name.lowercased())",
         deploymentTarget: ProjectEnvironment.default.deploymentTarget,
-        infoPlist: .extendingDefault(with: infoPlist),
+        infoPlist: .extendingDefault(with: defaultInfoPlist),
         sources: "Sources/**",
         resources: "Resources/**",
         scripts: [.swiftFormat, .swiftLint],


### PR DESCRIPTION
## Screenshots 📸

|Name|
|:-:|
|<img src="https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/5938bda0-afba-47f0-b0d9-8760f2dba594" width="33%"/>|

<br/><br/>

## 고민, 과정, 근거 💬

### 1. 지도 UI 구현

운동 세션에서 두 번째 화면에서 지도를 보여주는 UI를 구현했습니다.
아직은 위치가 이동될 때마다 그려지는 방식으로 구현했습니다., 백그라운드 진입 로직은 추후 구현할 예정입니다.


### 2. 네이밍 변경

- WorkoutSummaryViewController쪽의 네이밍을 수정했습니다.
  - WorkoutSummary -> WorkoutSession
  - ParticipantsCollectionViewCell -> SessionParticipantCell

### 3. Tuist Info.plist 설정값 수정

- 각 Target에 별도로 Info.plist를 넣어주어야 하는 경우가 있는데, 기본값으로 넘겨주는 값을 덮어씌우다보니 문제가 발생하게 되었습니다. 그래서 각 Target 메서드마다 갖고있어야 하는 Info.plist 코드는 메서드 내부로 옮기고, 추가로 덧붙일 Info.Plist를 외부에서 받아 처리하도록 수정했습니다.

<br/><br/>

## References 📋


1. [MapPolyline | Apple Developer Documentation](https://developer.apple.com/documentation/mapkit/mappolyline)
2. [What's New in MapKit | WWDC2015](https://developer.apple.com/wwdc15/206?time=1376)

<br/><br/>

---

- Closed: #12
