### PR TITLE
[GWL-74] CocoaCombine bind(to:) 추가

### DIFF
--- a/iOS/Projects/Shared/CombineCocoa/Project.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Project.swift
@@ -3,5 +3,9 @@ import ProjectDescriptionHelpers
 
 let project = Project.makeModule(
   name: "CombineCocoa",
-  targets: .custom(name: "CombineCocoa", product: .framework)
+  targets: .custom(
+    name: "CombineCocoa",
+    product: .framework,
+    testingOptions: [.unitTest]
+  )
 )

--- a/iOS/Projects/Shared/CombineCocoa/Sources/Publisher+bind.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Sources/Publisher+bind.swift
@@ -1,0 +1,17 @@
+//
+//  Publisher+bind.swift
+//  CombineCocoa
+//
+//  Created by 홍승현 on 11/23/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher where Failure == Never {
+  func bind<S>(to subject: S) -> AnyCancellable where S: Subject, S.Output == Output, S.Failure == Failure {
+    return sink { value in
+      subject.send(value)
+    }
+  }
+}

--- a/iOS/Projects/Shared/CombineCocoa/Tests/Publisher+bindTests.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Tests/Publisher+bindTests.swift
@@ -1,0 +1,69 @@
+//
+//  Publisher+bindTests.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by 홍승현 on 11/23/23.
+//
+
+@testable import CombineCocoa
+
+import Combine
+import XCTest
+
+final class Publisher_bindTests: XCTestCase {
+  private var subscriptions: Set<AnyCancellable> = []
+  private let publisher: PassthroughSubject<Void, Never> = .init()
+  private var sut: AnyPublisher<Void, Never>?
+
+
+  override func tearDown() {
+    for subscription in subscriptions {
+      subscription.cancel()
+    }
+    subscriptions.removeAll()
+  }
+
+  func testBindToPassthroughSubject() {
+    // assign
+    let expectation = XCTestExpectation(description: "PassthroughSubject should receive value")
+    let passthroughSubject = PassthroughSubject<String, Never>()
+    let testValue = "Test"
+
+    // act
+    Just(testValue)
+      .bind(to: passthroughSubject)
+      .store(in: &subscriptions)
+
+    // assert
+    passthroughSubject
+      .sink { receivedValue in
+        XCTAssertEqual(receivedValue, testValue)
+        expectation.fulfill()
+      }
+      .store(in: &subscriptions)
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testBindToCurrentValueSubject() {
+    // assign
+    let expectation = XCTestExpectation(description: "CurrentValueSubject should receive value")
+    let currentValueSubject = CurrentValueSubject<String, Never>("Initial Value")
+    let testValue = "Test"
+
+    // act
+    Just(testValue)
+      .bind(to: currentValueSubject)
+      .store(in: &subscriptions)
+
+    // assert
+    currentValueSubject
+      .sink { receivedValue in
+        XCTAssertEqual(receivedValue, testValue)
+        expectation.fulfill()
+      }
+      .store(in: &subscriptions)
+
+    wait(for: [expectation], timeout: 1.0)
+  }
+}

--- a/iOS/Projects/Shared/CombineCocoa/Tests/Publisher+bindTests.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Tests/Publisher+bindTests.swift
@@ -15,7 +15,6 @@ final class Publisher_bindTests: XCTestCase {
   private let publisher: PassthroughSubject<Void, Never> = .init()
   private var sut: AnyPublisher<Void, Never>?
 
-
   override func tearDown() {
     for subscription in subscriptions {
       subscription.cancel()
@@ -29,17 +28,17 @@ final class Publisher_bindTests: XCTestCase {
     let passthroughSubject = PassthroughSubject<String, Never>()
     let testValue = "Test"
 
-    // act
-    Just(testValue)
-      .bind(to: passthroughSubject)
-      .store(in: &subscriptions)
+    // act & assert
 
-    // assert
     passthroughSubject
       .sink { receivedValue in
         XCTAssertEqual(receivedValue, testValue)
         expectation.fulfill()
       }
+      .store(in: &subscriptions)
+
+    Just(testValue)
+      .bind(to: passthroughSubject)
       .store(in: &subscriptions)
 
     wait(for: [expectation], timeout: 1.0)


### PR DESCRIPTION
## 고민, 과정, 근거 💬

단순히 subject send하는 과정을 sink 클로저로 처리하는 것이 이쁘지 않아보였고, RxSwift 메서드에 착안하여 `bind(to:)`를 만들게 되었습니다.<sup>[[1]](#ref1)</sup>

```swift
let subject: PassthroughSubject<Void, Never> = .init()

// 전
button.publisher(.touchUpInside)
  .sink { _ in
    subject.send(())
  }
  .store(in: &subscriptions)



// 후
button.publisher(.touchUpInside)
  .map { _ in Void() }
  .bind(to: subject)
  .store(in: &subscriptions)
```

<br/><br/>

## References 📋


1. <a id="ref1">[Observable Bind.swift L19-L24](https://github.com/ReactiveX/RxSwift/blob/65bec4c253418c46ddc136424f46f333f086be1a/RxCocoa/Common/Observable%2BBind.swift#L19-L24)</a>

<br/><br/>

---

- Closed: #102
