### PR TITLE
[GWL-84] Workout Session 전체 뷰 구성 + Swiftformat CI 추가

### DIFF
--- a/.github/workflows/iOS_CI.yml
+++ b/.github/workflows/iOS_CI.yml
@@ -22,7 +22,7 @@ jobs:
         run: brew install swiftformat
 
       - name: Run Swiftformat
-        run: swiftformat . --config ${{env.working-directory}}/.swiftformat
+        run: swiftformat . --config .swiftformat
         working-directory: ${{env.working-directory}}
 
       - name: Check for changes

--- a/.github/workflows/iOS_CI.yml
+++ b/.github/workflows/iOS_CI.yml
@@ -22,7 +22,7 @@ jobs:
         run: brew install swiftformat
 
       - name: Run Swiftformat
-        run: swiftformat . --config .swiftformat
+        run: swiftformat ./Projects --config .swiftformat
         working-directory: ${{env.working-directory}}
 
       - name: Check for changes

--- a/.github/workflows/iOS_CI.yml
+++ b/.github/workflows/iOS_CI.yml
@@ -8,6 +8,32 @@ on:
     types: [labeled, opened, synchronize, reopened]
 
 jobs:
+  swift-format:
+    if: contains(github.event.pull_request.labels.*.name, '📱 iOS')
+    runs-on: macos-13
+    env:
+      working-directory: ./iOS
+
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Swiftformat
+        run: brew install swiftformat
+
+      - name: Run Swiftformat
+        run: swiftformat . --config ${{env.working-directory}}/.swiftformat
+        working-directory: ${{env.working-directory}}
+
+      - name: Check for changes
+        run: |
+          git diff
+          if [[ `git status --porcelain` ]]; then
+            echo "Code was formatted. Failing the job."
+            exit 1
+          fi
+        working-directory: ${{env.working-directory}}
+
   tuist-test:
     if: contains(github.event.pull_request.labels.*.name, '📱 iOS')
     runs-on: macos-13

--- a/iOS/Projects/Features/Record/Sources/Domain/UseCases/Protocol/RecordUpdateUseCaseRepresentable.swift
+++ b/iOS/Projects/Features/Record/Sources/Domain/UseCases/Protocol/RecordUpdateUseCaseRepresentable.swift
@@ -15,7 +15,7 @@ protocol RecordUpdateUseCaseRepresentable {
   func execute(date: Date) -> AnyPublisher<[Record], Error>
 }
 
-// MARK: - RecordUpdateUsecaseError
+// MARK: - RecordUpdateUseCaseError
 
 enum RecordUpdateUseCaseError: Error {
   case noRecord

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
@@ -9,8 +9,8 @@
 import Combine
 import CoreLocation
 import DesignSystem
-import MapKit
 import Log
+import MapKit
 import UIKit
 
 // MARK: - WorkoutRouteMapViewController

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewModel.swift
@@ -39,9 +39,6 @@ final class WorkoutRouteMapViewModel {
 
 extension WorkoutRouteMapViewModel: WorkoutRouteMapViewModelRepresentable {
   public func transform(input _: WorkoutRouteMapViewModelInput) -> WorkoutRouteMapViewModelOutput {
-    for subscription in subscriptions {
-      subscription.cancel()
-    }
     subscriptions.removeAll()
 
     let initialState: WorkoutRouteMapViewModelOutput = Just(.idle).eraseToAnyPublisher()

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
@@ -21,8 +21,6 @@ public final class WorkoutSessionViewController: UIViewController {
 
   private var subscriptions: Set<AnyCancellable> = []
 
-  private let endWorkoutSubject: PassthroughSubject<Void, Never> = .init()
-
   // MARK: UI Components
 
   private lazy var participantsCollectionView: UICollectionView = {
@@ -84,7 +82,7 @@ public final class WorkoutSessionViewController: UIViewController {
   }
 
   private func bind() {
-    let output = viewModel.transform(input: .init(endWorkoutPublisher: endWorkoutSubject.eraseToAnyPublisher()))
+    let output = viewModel.transform(input: .init())
     output.sink { state in
       switch state {
       case .idle:

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
@@ -25,26 +25,6 @@ public final class WorkoutSessionViewController: UIViewController {
 
   // MARK: UI Components
 
-  private let recordTimerLabel: UILabel = {
-    let label = UILabel()
-    label.font = .preferredFont(forTextStyle: .largeTitle)
-    label.text = "0분 0초"
-    return label
-  }()
-
-  private lazy var endWorkoutButton: UIButton = {
-    let button = UIButton(configuration: .mainCircularEnabled(title: "종료"))
-    button.configuration?.font = .preferredFont(forTextStyle: .largeTitle, with: .traitBold)
-    button.accessibilityHint = "운동을 종료합니다."
-    button.addAction(
-      UIAction { [weak self] _ in
-        self?.endWorkoutSubject.send(())
-      },
-      for: .touchUpInside
-    )
-    return button
-  }()
-
   private lazy var participantsCollectionView: UICollectionView = {
     let collectionView = UICollectionView(
       frame: .zero,
@@ -82,47 +62,19 @@ public final class WorkoutSessionViewController: UIViewController {
   // MARK: Configuration
 
   private func setupLayouts() {
-    view.addSubview(recordTimerLabel)
     view.addSubview(participantsCollectionView)
-    view.addSubview(endWorkoutButton)
   }
 
   private func setupConstraints() {
     let safeArea = view.safeAreaLayoutGuide
-    recordTimerLabel.translatesAutoresizingMaskIntoConstraints = false
-    endWorkoutButton.translatesAutoresizingMaskIntoConstraints = false
     participantsCollectionView.translatesAutoresizingMaskIntoConstraints = false
 
     NSLayoutConstraint.activate(
       [
-        recordTimerLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.horizontal),
-        recordTimerLabel.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.horizontal),
-        recordTimerLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: Metrics.recordTimerLabelTop),
-
-        participantsCollectionView.topAnchor.constraint(
-          equalTo: recordTimerLabel.bottomAnchor,
-          constant: Metrics.collectionViewTop
-        ),
-        participantsCollectionView.leadingAnchor.constraint(
-          equalTo: safeArea.leadingAnchor,
-          constant: Metrics.horizontal
-        ),
-        participantsCollectionView.trailingAnchor.constraint(
-          equalTo: safeArea.trailingAnchor,
-          constant: -Metrics.horizontal
-        ),
-        participantsCollectionView.bottomAnchor.constraint(
-          equalTo: endWorkoutButton.topAnchor,
-          constant: -Metrics.collectionViewBottom
-        ),
-
-        endWorkoutButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-        endWorkoutButton.widthAnchor.constraint(equalToConstant: Metrics.endingWorkoutButtonSize),
-        endWorkoutButton.heightAnchor.constraint(equalToConstant: Metrics.endingWorkoutButtonSize),
-        endWorkoutButton.bottomAnchor.constraint(
-          equalTo: safeArea.bottomAnchor,
-          constant: -Metrics.endingWorkoutButtonBottom
-        ),
+        participantsCollectionView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+        participantsCollectionView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+        participantsCollectionView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+        participantsCollectionView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
       ]
     )
   }
@@ -204,14 +156,7 @@ public final class WorkoutSessionViewController: UIViewController {
 
 private extension WorkoutSessionViewController {
   enum Metrics {
-    static let recordTimerLabelTop: CGFloat = 12
-    static let collectionViewTop: CGFloat = 12
-    static let collectionViewBottom: CGFloat = 44
     static let collectionViewItemSpacing: CGFloat = 6
-    static let horizontal: CGFloat = 36
-    static let endingWorkoutButtonBottom: CGFloat = 32
-
-    static let endingWorkoutButtonSize: CGFloat = 150
     static let collectionViewCellHeight: CGFloat = 84
   }
 }

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewModel.swift
@@ -10,9 +10,7 @@ import Combine
 
 // MARK: - WorkoutSessionViewModelInput
 
-public struct WorkoutSessionViewModelInput {
-  let endWorkoutPublisher: AnyPublisher<Void, Never>
-}
+public struct WorkoutSessionViewModelInput {}
 
 public typealias WorkoutSessionViewModelOutput = AnyPublisher<WorkoutSessionState, Never>
 
@@ -43,15 +41,11 @@ public final class WorkoutSessionViewModel {
 // MARK: WorkoutSessionViewModelRepresentable
 
 extension WorkoutSessionViewModel: WorkoutSessionViewModelRepresentable {
-  public func transform(input: WorkoutSessionViewModelInput) -> WorkoutSessionViewModelOutput {
+  public func transform(input _: WorkoutSessionViewModelInput) -> WorkoutSessionViewModelOutput {
     for subscription in subscriptions {
       subscription.cancel()
     }
     subscriptions.removeAll()
-
-    input.endWorkoutPublisher
-      .sink {}
-      .store(in: &subscriptions)
 
     let initialState: WorkoutSessionViewModelOutput = Just(.idle).eraseToAnyPublisher()
 

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewModel.swift
@@ -42,9 +42,6 @@ public final class WorkoutSessionViewModel {
 
 extension WorkoutSessionViewModel: WorkoutSessionViewModelRepresentable {
   public func transform(input _: WorkoutSessionViewModelInput) -> WorkoutSessionViewModelOutput {
-    for subscription in subscriptions {
-      subscription.cancel()
-    }
     subscriptions.removeAll()
 
     let initialState: WorkoutSessionViewModelOutput = Just(.idle).eraseToAnyPublisher()

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
@@ -1,0 +1,84 @@
+//
+//  WorkoutSessionContainerViewController.swift
+//  RecordFeature
+//
+//  Created by 홍승현 on 11/23/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import DesignSystem
+import UIKit
+
+// MARK: - WorkoutSessionContainerViewController
+
+final class WorkoutSessionContainerViewController: UIViewController {
+  // MARK: Properties
+
+  private let viewModel: WorkoutSessionContainerViewModelRepresentable
+
+  private var subscriptions: Set<AnyCancellable> = []
+
+  // MARK: UI Components
+
+  private let button: UIButton = .init(configuration: .mainEnabled(title: "test button"))
+
+  // MARK: Initializations
+
+  init(viewModel: WorkoutSessionContainerViewModelRepresentable) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  // MARK: Life Cycles
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    setupLayouts()
+    setupConstraints()
+    setupStyles()
+    bind()
+  }
+
+  // MARK: Configuration
+
+  private func setupLayouts() {
+    view.addSubview(button)
+  }
+
+  private func setupConstraints() {
+    button.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        button.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        button.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+      ]
+    )
+  }
+
+  private func setupStyles() {
+    view.backgroundColor = DesignSystemColor.primaryBackground
+  }
+
+  private func bind() {
+    let output = viewModel.transform(input: .init())
+    output.sink { state in
+      switch state {
+      case .idle:
+        break
+      }
+    }
+    .store(in: &subscriptions)
+  }
+}
+
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, xrOS 1.0, *)
+#Preview {
+  WorkoutSessionContainerViewController(viewModel: WorkoutSessionContainerViewModel())
+}

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
@@ -42,6 +42,8 @@ final class WorkoutSessionContainerViewController: UIViewController {
     return button
   }()
 
+  private lazy var pageControl: GWPageControl = .init(count: viewControllers.count)
+
   private lazy var pageViewController: UIPageViewController = {
     let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
     pageViewController.dataSource = self
@@ -76,6 +78,7 @@ final class WorkoutSessionContainerViewController: UIViewController {
     addChild(pageViewController)
     view.addSubview(recordTimerLabel)
     view.addSubview(pageViewController.view)
+    view.addSubview(pageControl)
     view.addSubview(endWorkoutButton)
     pageViewController.didMove(toParent: self)
 
@@ -90,6 +93,7 @@ final class WorkoutSessionContainerViewController: UIViewController {
     recordTimerLabel.translatesAutoresizingMaskIntoConstraints = false
     endWorkoutButton.translatesAutoresizingMaskIntoConstraints = false
     pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
+    pageControl.translatesAutoresizingMaskIntoConstraints = false
 
     NSLayoutConstraint.activate(
       [
@@ -100,7 +104,11 @@ final class WorkoutSessionContainerViewController: UIViewController {
         pageViewController.view.topAnchor.constraint(equalTo: recordTimerLabel.bottomAnchor, constant: Metrics.pageViewControllerTop),
         pageViewController.view.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.horizontal),
         pageViewController.view.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.horizontal),
-        pageViewController.view.bottomAnchor.constraint(equalTo: endWorkoutButton.topAnchor, constant: -Metrics.pageViewControllerBottom),
+        pageViewController.view.bottomAnchor.constraint(equalTo: pageControl.topAnchor, constant: -Metrics.pageViewControllerBottom),
+
+        pageControl.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        pageControl.bottomAnchor.constraint(equalTo: endWorkoutButton.topAnchor, constant: -Metrics.pageControlBottom),
+        pageControl.heightAnchor.constraint(equalToConstant: Metrics.pageControlHeight),
 
         endWorkoutButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         endWorkoutButton.widthAnchor.constraint(equalToConstant: Metrics.endingWorkoutButtonSize),
@@ -146,7 +154,7 @@ extension WorkoutSessionContainerViewController: UIPageViewControllerDataSource 
     guard viewControllers.count > previousIndex else {
       return nil
     }
-
+    pageControl.select(at: previousIndex)
     return viewControllers[previousIndex]
   }
 
@@ -165,7 +173,7 @@ extension WorkoutSessionContainerViewController: UIPageViewControllerDataSource 
     guard viewControllersCount > nextIndex else {
       return nil
     }
-
+    pageControl.select(at: nextIndex)
     return viewControllers[nextIndex]
   }
 }
@@ -178,9 +186,11 @@ private extension WorkoutSessionContainerViewController {
     static let recordTimerLabelTop: CGFloat = 12
     static let pageViewControllerTop: CGFloat = 12
     static let pageViewControllerBottom: CGFloat = 24
+    static let pageControlBottom: CGFloat = 12
     static let endingWorkoutButtonBottom: CGFloat = 32
 
     static let endingWorkoutButtonSize: CGFloat = 150
+    static let pageControlHeight: CGFloat = 8
   }
 }
 

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
@@ -19,6 +19,8 @@ final class WorkoutSessionContainerViewController: UIViewController {
 
   private var subscriptions: Set<AnyCancellable> = []
 
+  private let endWorkoutSubject: PassthroughSubject<Void, Never> = .init()
+
   // MARK: UI Components
 
   private let viewControllers: [UIViewController] = [
@@ -116,7 +118,7 @@ final class WorkoutSessionContainerViewController: UIViewController {
   }
 
   private func bind() {
-    let output = viewModel.transform(input: .init())
+    let output = viewModel.transform(input: .init(endWorkoutPublisher: endWorkoutSubject.eraseToAnyPublisher()))
     output.sink { state in
       switch state {
       case .idle:

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
@@ -11,7 +11,9 @@ import Foundation
 
 // MARK: - WorkoutSessionContainerViewModelInput
 
-public struct WorkoutSessionContainerViewModelInput {}
+public struct WorkoutSessionContainerViewModelInput {
+  let endWorkoutPublisher: AnyPublisher<Void, Never>
+}
 
 public typealias WorkoutSessionContainerViewModelOutput = AnyPublisher<WorkoutSessionContainerState, Never>
 
@@ -38,11 +40,15 @@ final class WorkoutSessionContainerViewModel {
 // MARK: WorkoutSessionContainerViewModelRepresentable
 
 extension WorkoutSessionContainerViewModel: WorkoutSessionContainerViewModelRepresentable {
-  public func transform(input _: WorkoutSessionContainerViewModelInput) -> WorkoutSessionContainerViewModelOutput {
+  public func transform(input: WorkoutSessionContainerViewModelInput) -> WorkoutSessionContainerViewModelOutput {
     for subscription in subscriptions {
       subscription.cancel()
     }
     subscriptions.removeAll()
+
+    input.endWorkoutPublisher
+      .sink {}
+      .store(in: &subscriptions)
 
     let initialState: WorkoutSessionContainerViewModelOutput = Just(.idle).eraseToAnyPublisher()
 

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  WorkoutSessionContainerViewModel.swift
+//  RecordFeature
+//
+//  Created by 홍승현 on 11/23/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+// MARK: - WorkoutSessionContainerViewModelInput
+
+public struct WorkoutSessionContainerViewModelInput {}
+
+public typealias WorkoutSessionContainerViewModelOutput = AnyPublisher<WorkoutSessionContainerState, Never>
+
+// MARK: - WorkoutSessionContainerState
+
+public enum WorkoutSessionContainerState {
+  case idle
+}
+
+// MARK: - WorkoutSessionContainerViewModelRepresentable
+
+protocol WorkoutSessionContainerViewModelRepresentable {
+  func transform(input: WorkoutSessionContainerViewModelInput) -> WorkoutSessionContainerViewModelOutput
+}
+
+// MARK: - WorkoutSessionContainerViewModel
+
+final class WorkoutSessionContainerViewModel {
+  // MARK: - Properties
+
+  private var subscriptions: Set<AnyCancellable> = []
+}
+
+// MARK: WorkoutSessionContainerViewModelRepresentable
+
+extension WorkoutSessionContainerViewModel: WorkoutSessionContainerViewModelRepresentable {
+  public func transform(input _: WorkoutSessionContainerViewModelInput) -> WorkoutSessionContainerViewModelOutput {
+    for subscription in subscriptions {
+      subscription.cancel()
+    }
+    subscriptions.removeAll()
+
+    let initialState: WorkoutSessionContainerViewModelOutput = Just(.idle).eraseToAnyPublisher()
+
+    return initialState
+  }
+}

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
@@ -41,9 +41,6 @@ final class WorkoutSessionContainerViewModel {
 
 extension WorkoutSessionContainerViewModel: WorkoutSessionContainerViewModelRepresentable {
   public func transform(input: WorkoutSessionContainerViewModelInput) -> WorkoutSessionContainerViewModelOutput {
-    for subscription in subscriptions {
-      subscription.cancel()
-    }
     subscriptions.removeAll()
 
     input.endWorkoutPublisher

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSummaryScene/WorkoutSummaryViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSummaryScene/WorkoutSummaryViewController.swift
@@ -122,16 +122,16 @@ final class WorkoutSummaryViewController: UIViewController {
     output
       .receive(on: DispatchQueue.main)
       .sink { [weak self] state in
-      switch state {
-      case .idle:
-        break
-      case let .fetchSummary(model):
-        self?.summaryCardView.configure(with: model)
-      case let .alert(error):
-        self?.showAlert(with: error)
+        switch state {
+        case .idle:
+          break
+        case let .fetchSummary(model):
+          self?.summaryCardView.configure(with: model)
+        case let .alert(error):
+          self?.showAlert(with: error)
+        }
       }
-    }
-    .store(in: &subscriptions)
+      .store(in: &subscriptions)
   }
 
   // MARK: - Custom Methods

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSummaryScene/WorkoutSummaryViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSummaryScene/WorkoutSummaryViewModel.swift
@@ -51,10 +51,6 @@ final class WorkoutSummaryViewModel {
 extension WorkoutSummaryViewModel: WorkoutSummaryViewModelRepresentable {
   public func transform(input: WorkoutSummaryViewModelInput) -> WorkoutSummaryViewModelOutput {
     // == Disposing of All Subscriptions ==
-
-    for subscription in subscriptions {
-      subscription.cancel()
-    }
     subscriptions.removeAll()
 
     // == Input Output Binding ==

--- a/iOS/Projects/Shared/Log/Sources/Logger.swift
+++ b/iOS/Projects/Shared/Log/Sources/Logger.swift
@@ -1,5 +1,5 @@
 //
-//  Log.swift
+//  Logger.swift
 //  DesignSystem
 //
 //  Created by 홍승현 on 11/23/23.
@@ -8,9 +8,10 @@
 
 import OSLog
 
+// MARK: - Log
+
 /// 로그
 public enum Log {
-
   /// Logger를 생성합니다.
   /// - Parameter category: Log를 구분하는 Category
   public static func make(with category: LogCategory = .default) -> Logger {
@@ -18,10 +19,10 @@ public enum Log {
   }
 }
 
+// MARK: - LogCategory
 
 /// 로그 카테고리
 public enum LogCategory: String {
-
   /// 기본값으로 들어갑니다.
   case `default`
 
@@ -31,7 +32,6 @@ public enum LogCategory: String {
   /// 네트워크 로그를 작성할 때 사용합니다.
   case network
 }
-
 
 private extension String {
   static let bundleIdentifier: String = Bundle.main.bundleIdentifier ?? "None"


### PR DESCRIPTION
## Screenshots 📸

|UI|
|:-:|
|<img src="https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/55e5a167-eba8-4c86-ba2f-e908bb61b8ac" width="50%"/>|
|View Hierarchy|
|![](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/c2a412f8-3e75-4d28-87e5-e12fa339f0c5)|

<br/><br/>

## 고민, 과정, 근거 💬

## UI

- 지도 뷰(Route Map)와 운동 세션(Workout Session)을 하나의 PageController로 설정
- GWPageControl를 설정했는데 원하는대로 뷰가 설정되지 않았음
   - @MaraMincho님과 상의 후 수정 예정


### CI

- Swiftformat이 적용되지 않은 상태이면 CI 실패가 뜨도록 설정


<br/><br/>

## References 📋

- 없음

---

- #112
