### PR TITLE
[GWL-125] GWPageController 스스로가 Size를 갖을 수 있도록 코드 변경

### DIFF
--- a/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
+++ b/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
@@ -31,8 +31,6 @@ public final class GWPageControl: UIView {
     return .init(width: pageControllerWidth, height: pageControllerHeight)
   }
 
-  // MARK: - 과연 UIVIew를 optional로 만드는게 맞을까?
-
   /// init에서 만약 5보다 큰 수나 2보다 작은 수가 입력되는 경우
   /// page 갯수가 2개로 설정 됩니다.
   public init(count: Int) {

--- a/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
+++ b/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
@@ -12,20 +12,31 @@ import UIKit
 // MARK: - GWPageControl
 
 public final class GWPageControl: UIView {
-  let numberOfPage: Int
-  var currentPageIndex: Int = 0
-  let spacing: CGFloat = 8
-  var pages: [UIView] = []
-  var pageswidthConstraint: [NSLayoutConstraint] = []
+  /// proeprty
+  private let numberOfPage: Int
+  private var currentPageIndex: Int = 0
+  private let spacing: CGFloat = 8
+  private var pages: [UIView] = []
+  private var pageswidthConstraint: [NSLayoutConstraint] = []
+
+  private var pageControllerWidth: CGFloat {
+    return .init(58 * numberOfPage - 58)
+  }
+
+  private var pageControllerHeight: CGFloat {
+    return .init(8)
+  }
+
+  override public var intrinsicContentSize: CGSize {
+    return .init(width: pageControllerWidth, height: pageControllerHeight)
+  }
 
   // MARK: - 과연 UIVIew를 optional로 만드는게 맞을까?
 
   /// init에서 만약 5보다 큰 수나 2보다 작은 수가 입력되는 경우
   /// page 갯수가 2개로 설정 됩니다.
   public init(count: Int) {
-    numberOfPage = (UIPageControlDefaultProperty.range).contains(count) ?
-      count :
-      UIPageControlDefaultProperty.numOfMinPage
+    numberOfPage = (UIPageControlDefaultProperty.range).contains(count) ? count : UIPageControlDefaultProperty.numOfMinPage
 
     super.init(frame: .zero)
 
@@ -81,7 +92,7 @@ private extension GWPageControl {
 
 public extension GWPageControl {
   func select(at pageIndex: Int) {
-    if pageIndex >= pages.count || currentPageIndex <= 0 {
+    if pageIndex >= pages.count || currentPageIndex < 0 {
       return
     }
     updateDeselectPage(at: currentPageIndex)
@@ -92,7 +103,7 @@ public extension GWPageControl {
   }
 
   func next() {
-    if currentPageIndex >= pages.count || currentPageIndex < 0 {
+    if currentPageIndex >= pages.count - 1 || currentPageIndex < 0 {
       return
     }
     updateDeselectPage(at: currentPageIndex)

--- a/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
+++ b/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
@@ -19,10 +19,8 @@ public final class GWPageControl: UIView {
   private var pages: [UIView] = []
   private var pageswidthConstraint: [NSLayoutConstraint] = []
 
-  
-  
   // itrinsicContentSize
-  
+
   /// pageController width value
   /// numOfPage = n, PageSpacing = 8
   /// selectedPageWidth = 40, unSelectedPageWidth = 10
@@ -30,6 +28,7 @@ public final class GWPageControl: UIView {
   private var pageControllerWidth: CGFloat {
     return .init(18 * numberOfPage + 22)
   }
+
   private var pageControllerHeight: CGFloat = 8
   override public var intrinsicContentSize: CGSize {
     return .init(width: pageControllerWidth, height: pageControllerHeight)

--- a/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
+++ b/iOS/Projects/Shared/DesignSystem/Sources/GWPageConrol.swift
@@ -19,14 +19,18 @@ public final class GWPageControl: UIView {
   private var pages: [UIView] = []
   private var pageswidthConstraint: [NSLayoutConstraint] = []
 
+  
+  
+  // itrinsicContentSize
+  
+  /// pageController width value
+  /// numOfPage = n, PageSpacing = 8
+  /// selectedPageWidth = 40, unSelectedPageWidth = 10
+  /// pageControlWidth = 40 + 10(n - 1) + 8(n - 1) = 18n + 22
   private var pageControllerWidth: CGFloat {
-    return .init(58 * numberOfPage - 58)
+    return .init(18 * numberOfPage + 22)
   }
-
-  private var pageControllerHeight: CGFloat {
-    return .init(8)
-  }
-
+  private var pageControllerHeight: CGFloat = 8
   override public var intrinsicContentSize: CGSize {
     return .init(width: pageControllerWidth, height: pageControllerHeight)
   }


### PR DESCRIPTION
## Screenshots 📸

|GWPageControl|
|:-:|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/e2b18cb4-364d-4e28-804c-070d5f891142)|

<br/><br/>

## 고민, 과정, 근거 💬

### intrinsicContentSize너는 무엇이냐?
- UILabel이 스스로 크기를 갖을 수 있는 이유는 intrinsicContentSize 때문
- 실제 CustomView에서도 intrinsicConstSize를 override하여 ContentSize를 갖게 함
- 이를 통해 언급했던 버그 수정
   -  https://github.com/boostcampwm2023/iOS08-WeTri/pull/117

<br/>

### 차후 고민점 
언제 intrinsicContentSize가 호출되는지 확인

<br/>

<br/><br/>

## References 📋
https://medium.com/@vialyx/import-uikit-what-is-intrinsic-content-size-20ae302f21f3

<br/><br/>

---

- Closed: #125 
