### PR TITLE
[GWL-37] CocoaCombine withLatestFrom 추가 + Code Coverage 100%

### DIFF
--- a/iOS/Projects/Shared/CombineCocoa/Sources/EventSubscription.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Sources/EventSubscription.swift
@@ -9,28 +9,28 @@
 import Combine
 import UIKit
 
-class EventSubscription<EventSubscriber: Subscriber>:
+final class EventSubscription<EventSubscriber: Subscriber>:
   Subscription where EventSubscriber.Input == UIControl, EventSubscriber.Failure == Never {
   func request(_: Subscribers.Demand) {}
 
   func cancel() {
     subscriber = nil
-    control.removeTarget(self, action: #selector(eventDidOccur), for: event)
+    control.removeAction(action, for: event)
   }
 
-  @objc func eventDidOccur() {
-    _ = subscriber?.receive(control)
-  }
-
-  let control: UIControl
-  let event: UIControl.Event
-  var subscriber: EventSubscriber?
+  private let control: UIControl
+  private let event: UIControl.Event
+  private var subscriber: EventSubscriber?
+  private let action: UIAction
 
   init(control: UIControl, event: UIControl.Event, subscriber: EventSubscriber) {
     self.control = control
     self.event = event
     self.subscriber = subscriber
+    action = .init { _ in
+      _ = subscriber.receive(control)
+    }
 
-    control.addTarget(self, action: #selector(eventDidOccur), for: event)
+    control.addAction(action, for: event)
   }
 }

--- a/iOS/Projects/Shared/CombineCocoa/Sources/Publisher+withLatestFrom.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Sources/Publisher+withLatestFrom.swift
@@ -1,0 +1,114 @@
+//
+//  Publisher+withLatestFrom.swift
+//  CombineCocoa
+//
+//  Created by 홍승현 on 11/26/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+
+public extension Publisher {
+  func withLatestFrom<Other: Publisher, Result>(
+    _ other: Other,
+    transform: @escaping (Output, Other.Output) -> Result
+  ) -> Publishers.WithLatestFrom<Self, Other, Result> {
+    return .init(upstream: self, other: other, resultClosure: transform)
+  }
+
+  func withLatestFrom<Other: Publisher>(_ other: Other) -> Publishers.WithLatestFrom<Self, Other, Other.Output> {
+    return .init(upstream: self, other: other) { $1 }
+  }
+}
+
+// MARK: - Publishers.WithLatestFrom
+
+public extension Publishers {
+  struct WithLatestFrom<Upstream: Publisher, Other: Publisher, Output>: Publisher where Upstream.Failure == Other.Failure {
+    /// The kind of errors this publisher might publish.
+    ///
+    /// This publisher produces the failure type shared by its upstream publishers.
+    public typealias Failure = Upstream.Failure
+
+    public let upstream: Upstream
+    public let other: Other
+    public let resultClosure: (Upstream.Output, Other.Output) -> Output
+
+    public init(
+      upstream: Upstream,
+      other: Other,
+      resultClosure: @escaping (Upstream.Output, Other.Output) -> Output
+    ) {
+      self.upstream = upstream
+      self.other = other
+      self.resultClosure = resultClosure
+    }
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Upstream.Failure == S.Failure, Output == S.Input {
+      let subscription = WithLatestFromSubscription(
+        subscriber: subscriber,
+        resultClosure: resultClosure,
+        upstream: upstream,
+        other: other
+      )
+      subscriber.receive(subscription: subscription)
+    }
+  }
+}
+
+// MARK: - Publishers.WithLatestFrom.WithLatestFromSubscription
+
+private extension Publishers.WithLatestFrom {
+  final class WithLatestFromSubscription<S: Subscriber>: Subscription where S.Input == Output, S.Failure == Failure {
+    private let subscriber: S
+    private let resultClosure: (Upstream.Output, Other.Output) -> Output
+    private let upstream: Upstream
+    private let other: Other
+    private var otherLatestValue: Other.Output?
+
+    private var upstreamSubscription: Cancellable?
+    private var otherSubscription: Cancellable?
+
+    init(
+      subscriber: S,
+      resultClosure: @escaping (Upstream.Output, Other.Output) -> Output,
+      upstream: Upstream,
+      other: Other
+    ) {
+      self.subscriber = subscriber
+      self.resultClosure = resultClosure
+      self.upstream = upstream
+      self.other = other
+      trackLatestFromOther()
+    }
+
+    private func trackLatestFromOther() {
+      let subscriber = AnySubscriber<Other.Output, Other.Failure> { [weak self] subscription in
+        self?.otherSubscription = subscription
+        subscription.request(.unlimited)
+      } receiveValue: { [weak self] output in
+        self?.otherLatestValue = output
+        return .unlimited
+      }
+
+      other.subscribe(subscriber)
+    }
+
+    func request(_: Subscribers.Demand) {
+      upstreamSubscription = upstream
+        .sink { [subscriber] completion in
+          subscriber.receive(completion: completion)
+        } receiveValue: { [weak self] output in
+          guard let self,
+                let otherLatestValue
+          else { return }
+          _ = subscriber.receive(resultClosure(output, otherLatestValue))
+        }
+    }
+
+    func cancel() {
+      upstreamSubscription = nil
+      otherSubscription = nil
+    }
+  }
+}

--- a/iOS/Projects/Shared/CombineCocoa/Tests/Publisher+WithLatestFromTests.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Tests/Publisher+WithLatestFromTests.swift
@@ -1,0 +1,148 @@
+//
+//  Publisher+WithLatestFromTests.swift
+//  CombineCocoaTests
+//
+//  Created by 홍승현 on 11/26/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+@testable import CombineCocoa
+
+import Combine
+import XCTest
+
+final class PublisherWithLatestFromTests: XCTestCase {
+  private var subscriptions: Set<AnyCancellable> = []
+
+  private enum TestError: Error {
+    case test
+  }
+
+  override func tearDown() {
+    subscriptions.removeAll()
+  }
+
+  func testWithLatestFrom_CombinesValuesCorrectly() {
+    // assign
+    let expectation = XCTestExpectation(description: "Received combined value")
+    let upstreamSubject = PassthroughSubject<Int, Never>()
+    let otherSubject = PassthroughSubject<String, Never>()
+
+    // act
+    upstreamSubject
+      .withLatestFrom(otherSubject) { number, string in "\(number)-\(string)" }
+      .sink { combinedValue in
+        XCTAssertEqual(combinedValue, "1-A")
+        expectation.fulfill()
+      }
+      .store(in: &subscriptions)
+
+    otherSubject.send("A")
+    upstreamSubject.send(1)
+
+    // assert
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testWithLatestFrom_NoEmissionWithoutSecondaryEmission() {
+    // assign
+    let upstreamSubject = PassthroughSubject<Int, Never>()
+    let otherSubject = PassthroughSubject<String, Never>()
+    var receivedValues = [String]()
+
+    // act
+    upstreamSubject
+      .withLatestFrom(otherSubject) { "\($0)-\($1)" }
+      .sink { receivedValues.append($0) }
+      .store(in: &subscriptions)
+
+    upstreamSubject.send(1)
+
+    // assert
+    XCTAssertTrue(receivedValues.isEmpty, "Should not emit values without both publishers emitting")
+  }
+
+  func testWithLatestFrom_UsesLatestValueFromSecondary() {
+    // assign
+    let upstreamSubject = PassthroughSubject<Int, Never>()
+    let otherSubject = PassthroughSubject<String, Never>()
+    var latestReceivedValue = ""
+
+    // act
+    upstreamSubject
+      .withLatestFrom(otherSubject) { "\($0)-\($1)" }
+      .sink { latestReceivedValue = $0 }
+      .store(in: &subscriptions)
+
+    otherSubject.send("A")
+    otherSubject.send("B") // 현재 제일 최신 값
+    upstreamSubject.send(1)
+
+    // assert
+    XCTAssertEqual(latestReceivedValue, "1-B", "Should use the latest value from the secondary publisher")
+  }
+
+  func testWithLatestFrom_CompletesWhenPrimaryCompletes() {
+    // assign
+    let upstreamSubject = PassthroughSubject<Int, Never>()
+    let otherSubject = PassthroughSubject<String, Never>()
+    let expectation = XCTestExpectation(description: "Completion")
+
+    // act
+    upstreamSubject
+      .withLatestFrom(otherSubject) { "\($0)-\($1)" }
+      .sink { _ in
+        expectation.fulfill()
+      } receiveValue: { _ in
+      }
+      .store(in: &subscriptions)
+
+    upstreamSubject.send(completion: .finished)
+
+    // assert
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testWithLatestFrom_PropagatesErrors() {
+    // assign
+    let upstreamSubject = PassthroughSubject<Int, TestError>()
+    let otherSubject = PassthroughSubject<String, TestError>()
+    let expectation = XCTestExpectation(description: "Error received")
+
+    // act
+    upstreamSubject
+      .withLatestFrom(otherSubject) { "\($0)-\($1)" }
+      .sink {
+        if case .failure = $0 {
+          expectation.fulfill()
+        }
+      } receiveValue: { _ in
+      }
+      .store(in: &subscriptions)
+
+    upstreamSubject.send(completion: .failure(TestError.test))
+
+    // assert
+    wait(for: [expectation], timeout: 1.0)
+  }
+
+  func testWithLatestFrom_SecondaryLatestValueUsed() {
+    // assign
+    let upstreamSubject = PassthroughSubject<Int, Never>()
+    let otherSubject = PassthroughSubject<String, Never>()
+    var latestReceivedValue = ""
+
+    // act
+    upstreamSubject
+      .withLatestFrom(otherSubject)
+      .sink { latestReceivedValue = $0 }
+      .store(in: &subscriptions)
+
+    otherSubject.send("A")
+    otherSubject.send("B") // 최신 값
+    upstreamSubject.send(1)
+
+    // assert
+    XCTAssertEqual(latestReceivedValue, "B", "Should use the latest value from the secondary publisher when the primary publisher emits")
+  }
+}

--- a/iOS/Projects/Shared/CombineCocoa/Tests/UIControl+PublisherTests.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Tests/UIControl+PublisherTests.swift
@@ -24,10 +24,11 @@ final class UIControlPublisherTests: XCTestCase {
     let event: UIControl.Event = .touchUpInside
     var eventFired = false
 
-    let cancellable = control.publisher(event)
+    control.publisher(event)
       .sink { _ in
         eventFired = true
       }
+      .store(in: &subscriptions)
 
     control.sendActions(for: event)
 
@@ -39,16 +40,14 @@ final class UIControlPublisherTests: XCTestCase {
     let event: UIControl.Event = .touchUpInside
     var eventFired = false
 
-    var cancellable: AnyCancellable? = control.publisher(event)
+    let cancellable: AnyCancellable = control.publisher(event)
       .sink { _ in
         eventFired = true
       }
 
-    cancellable?.cancel()
+    cancellable.cancel()
     control.sendActions(for: event)
 
     XCTAssertFalse(eventFired, "Event should not be received after the subscription is canceled")
   }
-
-
 }

--- a/iOS/Projects/Shared/CombineCocoa/Tests/UIControl+PublisherTests.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Tests/UIControl+PublisherTests.swift
@@ -1,0 +1,54 @@
+//
+//  UIControl+PublisherTests.swift
+//  CombineCocoaTests
+//
+//  Created by 홍승현 on 11/26/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+@testable import CombineCocoa
+
+import Combine
+import UIKit
+import XCTest
+
+final class UIControlPublisherTests: XCTestCase {
+  private var subscriptions: Set<AnyCancellable> = []
+
+  override func tearDown() {
+    subscriptions.removeAll()
+  }
+
+  func testEventFiring() {
+    let control = UIControl()
+    let event: UIControl.Event = .touchUpInside
+    var eventFired = false
+
+    let cancellable = control.publisher(event)
+      .sink { _ in
+        eventFired = true
+      }
+
+    control.sendActions(for: event)
+
+    XCTAssertTrue(eventFired, "Event should be fired and received by the publisher")
+  }
+
+  func testSubscriptionCancellation() {
+    let control = UIControl()
+    let event: UIControl.Event = .touchUpInside
+    var eventFired = false
+
+    var cancellable: AnyCancellable? = control.publisher(event)
+      .sink { _ in
+        eventFired = true
+      }
+
+    cancellable?.cancel()
+    control.sendActions(for: event)
+
+    XCTAssertFalse(eventFired, "Event should not be received after the subscription is canceled")
+  }
+
+
+}


### PR DESCRIPTION
## Screenshots 📸

|Code Coverage 100%|
|:-:|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/4f941fae-5305-4262-a1fc-03eba70f795c)|

<br/><br/>

## 고민, 과정, 근거 💬

- #130 에서 WithLatestFrom이 필요해서 추가하였습니다.
- 그리고 미비된 테스트 코드를 추가해서 CombineCocoa 한정 Code coverage 100% 달성했습니다. 🎉🎉
   - `@objc`는 테스트하기가 어려워서 UIAction으로 변경했어요. addTarget 대신에 addAction을 써서요!


<br/><br/>

## References 📋

1. [Combine+WithLatestFrom.swift](https://gist.github.com/freak4pc/8d46ea6a6f5e5902c3fb5eba440a55c3)

<br/><br/>

---

- Closed: #37
