### PR TITLE
[GWL-151] 웹소캣 AuthGuard 구현 -> 검증 verify 메서드 구현

### DIFF
--- a/BackEnd/src/live-workouts/events/events.module.ts
+++ b/BackEnd/src/live-workouts/events/events.module.ts
@@ -2,8 +2,22 @@ import { Module } from '@nestjs/common';
 import { EventsService } from './events.service';
 import { EventsGateway } from './events.gateway';
 import { ExtensionWebSocketService } from './extensionWebSocket.service';
+import { JwtModule } from '@nestjs/jwt';
+import { UsersModule } from '../../users/users.module';
+import { ProfilesModule } from '../../profiles/profiles.module';
+import { AuthController } from '../../auth/auth.controller';
+import { AuthService } from '../../auth/auth.service';
+import { AuthAppleService } from '../../auth/auth-apple.service';
 
 @Module({
-  providers: [EventsGateway, EventsService, ExtensionWebSocketService],
+  imports: [JwtModule.register({}), UsersModule, ProfilesModule],
+  controllers: [AuthController],
+  providers: [
+    EventsGateway,
+    EventsService,
+    ExtensionWebSocketService,
+    AuthService,
+    AuthAppleService,
+  ],
 })
 export class EventsModule {}

--- a/BackEnd/src/live-workouts/events/types/custom-websocket.type.ts
+++ b/BackEnd/src/live-workouts/events/types/custom-websocket.type.ts
@@ -1,4 +1,5 @@
 import * as WebSocket from 'ws';
+import { Profile } from '../../../profiles/entities/profiles.entity';
 
 export interface WetriServer extends WebSocket.Server {
   clientMap: Map<string, WetriWebSocket>;
@@ -15,4 +16,8 @@ export interface WetriWebSocket extends WebSocket {
   join: (roomName: string) => void;
   leave: (roomName: string) => void;
   to: (roomName: string) => { emit: (event: string, message: string) => void };
+  authorization?: string;
+  profile?: Profile;
+  token?: string;
+  tokenType?: string;
 }


### PR DESCRIPTION
## Screenshots 📸

|웹 소켓 검증 로직 구현|
|:-:|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/56383948/9e64cec1-f715-4f64-87fe-b6b8ee021036)|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/56383948/2d18765f-ae40-4be9-8694-c9b7f86c2aa5)|

<br/><br/>

## 고민, 과정, 근거 💬

<br/>

- 처음에는 UseGuard를 이용해서 WebsocketGuard를 구현하려고 했습니다. 하지만, 소켓이 연결된 후에 클라이언트가 메시지를 보내기 전까지 작동하지 않음을 보았습니다.
- handdleConnection이 Ws으로 연결전 HTTP를 통해 업그레이드 헤더를 보내는 것을 확인했습니다.
- 이후 handdleConnection위에 UseGuard를 달았지만, 작동하지 않았고, nest 공식 github에도 그와 관련된 게시물을 보았습니다.
- 방법은 시작할 때 미들웨어를 두고 검증하는 것입니다.
- 하지만, 직접 미들웨어를 만들어서 하기에는 남아있는 기능도 많았고, WebSocket과 SocketIO의 차이점으로인해 뒤로 미뤘습니다.
- 검증하는 로직을 메서드로 작성해서 handdleconnection에 추가했습니다.
- 그 외에 UseGuard를 이용하면 WebSocket 통신 중간에도, 토큰을 이용한 검증이 가능합니다.

<br/>

## References 📋


<br/>

- [this guard is not work](https://github.com/nestjs/nest/issues/9231)

<br/>

---

- Closed: #151 
