### PR TITLE
[GWL-158] redis 연결, redis 룸에 참가, 떠나기 ,redis pub/sub을 이용해서 브로드캐스트

### DIFF
--- a/BackEnd/src/app.module.ts
+++ b/BackEnd/src/app.module.ts
@@ -10,16 +10,13 @@ import { RecordsModule } from './records/records.module';
 import { WorkoutsModule } from './workouts/workouts.module';
 import { EventsModule } from './live-workouts/events/events.module';
 import { MatchesModule } from './live-workouts/matches/matches.module';
-import { RedisModule } from '@songkeys/nestjs-redis';
-import { RedisConfigService } from './config/redis.config';
 import { AdminModule } from './admin/admin.module';
+import { RedisModule } from './common/redis.module';
 
 @Module({
   imports: [
     TypeOrmModule.forRoot(typeOrmConfig),
-    RedisModule.forRootAsync({
-      useClass: RedisConfigService,
-    }),
+    RedisModule,
     AuthModule,
     UsersModule,
     ProfilesModule,

--- a/BackEnd/src/common/redis.module.ts
+++ b/BackEnd/src/common/redis.module.ts
@@ -4,20 +4,20 @@ import { redisConfig } from 'src/config/redis.config';
 
 @Global()
 @Module({
-    providers: [
-        {
-            provide: 'DATA_REDIS',
-            useFactory: () => {
-                return new Redis(redisConfig);
-            }
-        }, 
-        {
-            provide: 'SUBSCRIBE_REDIS',
-            useFactory: () => {
-                return new Redis(redisConfig);
-            }
-        }, 
-    ],
-    exports: ['DATA_REDIS', 'SUBSCRIBE_REDIS'],
+  providers: [
+    {
+      provide: 'DATA_REDIS',
+      useFactory: () => {
+        return new Redis(redisConfig);
+      },
+    },
+    {
+      provide: 'SUBSCRIBE_REDIS',
+      useFactory: () => {
+        return new Redis(redisConfig);
+      },
+    },
+  ],
+  exports: ['DATA_REDIS', 'SUBSCRIBE_REDIS'],
 })
 export class RedisModule {}

--- a/BackEnd/src/common/redis.module.ts
+++ b/BackEnd/src/common/redis.module.ts
@@ -1,0 +1,23 @@
+import { Module, Global } from '@nestjs/common';
+import Redis from 'ioredis';
+import { redisConfig } from 'src/config/redis.config';
+
+@Global()
+@Module({
+    providers: [
+        {
+            provide: 'DATA_REDIS',
+            useFactory: () => {
+                return new Redis(redisConfig);
+            }
+        }, 
+        {
+            provide: 'SUBSCRIBE_REDIS',
+            useFactory: () => {
+                return new Redis(redisConfig);
+            }
+        }, 
+    ],
+    exports: ['DATA_REDIS', 'SUBSCRIBE_REDIS'],
+})
+export class RedisModule {}

--- a/BackEnd/src/config/redis.config.ts
+++ b/BackEnd/src/config/redis.config.ts
@@ -13,7 +13,7 @@ export const redisConfig: object = {
   port: parseInt(process.env.REDIS_PORT),
   enableReadyCheck: true,
   enableOfflineQueue: true,
-}
+};
 
 // @Injectable()
 // export class RedisConfigService implements RedisOptionsFactory {

--- a/BackEnd/src/config/redis.config.ts
+++ b/BackEnd/src/config/redis.config.ts
@@ -8,15 +8,25 @@ import * as process from 'process';
 
 dotenv.config();
 
-@Injectable()
-export class RedisConfigService implements RedisOptionsFactory {
-  createRedisOptions(): RedisModuleOptions {
-    return {
-      readyLog: true,
-      config: {
-        host: process.env.REDIS_HOST,
-        port: parseInt(process.env.REDIS_PORT),
-      },
-    };
-  }
+export const redisConfig: object = {
+  host: process.env.REDIS_HOST,
+  port: parseInt(process.env.REDIS_PORT),
+  enableReadyCheck: true,
+  enableOfflineQueue: true,
 }
+
+// @Injectable()
+// export class RedisConfigService implements RedisOptionsFactory {
+//   createRedisOptions(): RedisModuleOptions {
+//     return {
+//       readyLog: true,
+//       config: [
+//         {
+//           name: 'subscribe',
+//           host: process.env.REDIS_HOST,
+//           port: parseInt(process.env.REDIS_PORT),
+//         }
+//       ],
+//     };
+//   }
+// }

--- a/BackEnd/src/config/redis.config.ts
+++ b/BackEnd/src/config/redis.config.ts
@@ -1,8 +1,3 @@
-import { Injectable } from '@nestjs/common';
-import {
-  RedisModuleOptions,
-  RedisOptionsFactory,
-} from '@songkeys/nestjs-redis';
 import * as dotenv from 'dotenv';
 import * as process from 'process';
 
@@ -14,19 +9,3 @@ export const redisConfig: object = {
   enableReadyCheck: true,
   enableOfflineQueue: true,
 };
-
-// @Injectable()
-// export class RedisConfigService implements RedisOptionsFactory {
-//   createRedisOptions(): RedisModuleOptions {
-//     return {
-//       readyLog: true,
-//       config: [
-//         {
-//           name: 'subscribe',
-//           host: process.env.REDIS_HOST,
-//           port: parseInt(process.env.REDIS_PORT),
-//         }
-//       ],
-//     };
-//   }
-// }

--- a/BackEnd/src/live-workouts/events/events.gateway.ts
+++ b/BackEnd/src/live-workouts/events/events.gateway.ts
@@ -27,6 +27,8 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   handleConnection(client: WetriWebSocket, ...args: any[]): any {
     this.extensionWebSocketService.webSocket(client, this.server);
+    client.join('room1');
+    this.server.to('room1').emit('event', 'message');
   }
 
   @SubscribeMessage('events')

--- a/BackEnd/src/live-workouts/events/events.gateway.ts
+++ b/BackEnd/src/live-workouts/events/events.gateway.ts
@@ -27,9 +27,6 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   handleConnection(client: WetriWebSocket, ...args: any[]): any {
     this.extensionWebSocketService.webSocket(client, this.server);
-    client.join('room1');
-    client.join('room2');
-    this.server.to('room1').emit('event_name', 'msg');
   }
 
   @SubscribeMessage('events')

--- a/BackEnd/src/live-workouts/events/events.gateway.ts
+++ b/BackEnd/src/live-workouts/events/events.gateway.ts
@@ -28,6 +28,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   handleConnection(client: WetriWebSocket, ...args: any[]): any {
     this.extensionWebSocketService.webSocket(client, this.server);
     client.join('room1');
+    client.join('room2');
     this.server.to('room1').emit('event_name', 'msg');
   }
 
@@ -67,6 +68,6 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   handleDisconnect(client: any) {
-    throw new Error('Method not implemented.');
+    // throw new Error('Method not implemented.');
   }
 }

--- a/BackEnd/src/live-workouts/events/events.module.ts
+++ b/BackEnd/src/live-workouts/events/events.module.ts
@@ -4,6 +4,10 @@ import { EventsGateway } from './events.gateway';
 import { ExtensionWebSocketService } from './extensionWebSocket.service';
 
 @Module({
-  providers: [EventsGateway, EventsService, ExtensionWebSocketService],
+  providers: [
+    EventsGateway, 
+    EventsService, 
+    ExtensionWebSocketService
+  ],
 })
 export class EventsModule {}

--- a/BackEnd/src/live-workouts/events/events.module.ts
+++ b/BackEnd/src/live-workouts/events/events.module.ts
@@ -4,10 +4,6 @@ import { EventsGateway } from './events.gateway';
 import { ExtensionWebSocketService } from './extensionWebSocket.service';
 
 @Module({
-  providers: [
-    EventsGateway, 
-    EventsService, 
-    ExtensionWebSocketService
-  ],
+  providers: [EventsGateway, EventsService, ExtensionWebSocketService],
 })
 export class EventsModule {}

--- a/BackEnd/src/live-workouts/events/extensionWebSocket.service.ts
+++ b/BackEnd/src/live-workouts/events/extensionWebSocket.service.ts
@@ -7,20 +7,16 @@ import { ExtensionWebSocketServer } from './extensions/extensionWebSocketServer'
 
 @Injectable()
 export class ExtensionWebSocketService {
-    constructor(
-        @Inject('DATA_REDIS') private readonly redisData: Redis,
-        @Inject('SUBSCRIBE_REDIS') private readonly redisSubscribe: Redis,
-    ) { }
+  constructor(
+    @Inject('DATA_REDIS') private readonly redisData: Redis,
+    @Inject('SUBSCRIBE_REDIS') private readonly redisSubscribe: Redis,
+  ) {}
 
-    webSocketServer(server: WetriServer) {
-        new ExtensionWebSocketServer(
-            server, 
-            this.redisData,
-            this.redisSubscribe
-        );
-    }
+  webSocketServer(server: WetriServer) {
+    new ExtensionWebSocketServer(server, this.redisData, this.redisSubscribe);
+  }
 
-    webSocket(client: WetriWebSocket, server: WetriServer) {
-        new ExtensionWebSocket(client, server);
-    }
+  webSocket(client: WetriWebSocket, server: WetriServer) {
+    new ExtensionWebSocket(client, server);
+  }
 }

--- a/BackEnd/src/live-workouts/events/extensionWebSocket.service.ts
+++ b/BackEnd/src/live-workouts/events/extensionWebSocket.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@nestjs/common';
+import { Redis } from 'ioredis';
+import { Inject, Injectable } from '@nestjs/common';
 
 import { WetriServer, WetriWebSocket } from './types/custom-websocket.type';
 import { ExtensionWebSocket } from './extensions/extensionWebSocket';
@@ -6,11 +7,20 @@ import { ExtensionWebSocketServer } from './extensions/extensionWebSocketServer'
 
 @Injectable()
 export class ExtensionWebSocketService {
-  webSocketServer(server: WetriServer) {
-    new ExtensionWebSocketServer(server);
-  }
+    constructor(
+        @Inject('DATA_REDIS') private readonly redisData: Redis,
+        @Inject('SUBSCRIBE_REDIS') private readonly redisSubscribe: Redis,
+    ) { }
 
-  webSocket(client: WetriWebSocket, server: WetriServer) {
-    new ExtensionWebSocket(client, server);
-  }
+    webSocketServer(server: WetriServer) {
+        new ExtensionWebSocketServer(
+            server, 
+            this.redisData,
+            this.redisSubscribe
+        );
+    }
+
+    webSocket(client: WetriWebSocket, server: WetriServer) {
+        new ExtensionWebSocket(client, server);
+    }
 }

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocket.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocket.ts
@@ -32,20 +32,8 @@ export class ExtensionWebSocket {
   to(roomId: string) {
     return {
       emit: (event: string, message: string) => {
-        if (
-          this.server.rooms.has(roomId) &&
-          this.server.rooms.get(roomId).has(this.id)
-        ) {
-          const room = this.server.rooms.get(roomId);
-          room.forEach((clientId) => {
-            if (clientId !== this.id) {
-              this.server.clientMap
-                .get(clientId)
-                .send(JSON.stringify({ event, message }));
-            }
-          });
-        }
-      },
+        this.server.to(roomId).emit(event, message, this.id);
+      }
     };
   }
 }

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocket.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocket.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { WetriServer, WetriWebSocket } from '../types/custom-websocket.type';
 
-
 export class ExtensionWebSocket {
   server: WetriServer;
   id: string;

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocket.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocket.ts
@@ -12,31 +12,32 @@ export class ExtensionWebSocket {
     client.leave = this.leave;
     client.to = this.to;
     client.server.clientMap.set(client.id, client);
-    // client.on('close', () => {
-    //   if (client.server.sids.has(client.id)) {
-    //     client.server.sids.get(client.id).forEach((roomName) => {
-    //       client.leave(roomName);
-    //     });
-    //   }
-    // });
+    client.on('close', () => {
+      if (client.server.sids.has(client.id)) {
+        client.server.sids.get(client.id).forEach((roomId) => {
+          client.leave(roomId);
+          client.server.clientMap.delete(client.id);
+        });
+      }
+    });
   }
 
-  join(roomName: string) {
-    this.server.joinRoom(this.id, roomName);
+  join(roomId: string) {
+    this.server.joinRoom(this.id, roomId);
   }
 
-  leave(roomName: string) {
-    this.server.leaveRoom(this.id, roomName);
+  leave(roomId: string) {
+    this.server.leaveRoom(this.id, roomId);
   }
 
-  to(roomName: string) {
+  to(roomId: string) {
     return {
       emit: (event: string, message: string) => {
         if (
-          this.server.rooms.has(roomName) &&
-          this.server.rooms.get(roomName).has(this.id)
+          this.server.rooms.has(roomId) &&
+          this.server.rooms.get(roomId).has(this.id)
         ) {
-          const room = this.server.rooms.get(roomName);
+          const room = this.server.rooms.get(roomId);
           room.forEach((clientId) => {
             if (clientId !== this.id) {
               this.server.clientMap

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
@@ -27,7 +27,6 @@ export class ExtensionWebSocketServer {
           await redisData.srem(value, key);
         });
       });
-      process.exit();
     });
     process.on('SIGINT', () => process.exit());
     process.on('SIGTERM', () => process.exit());

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
@@ -19,16 +19,16 @@ export class ExtensionWebSocketServer {
     server.to = this.to;
     server.subscribe = this.subscribe;
     server.unSubscribe = this.unSubscribe;
-    server.handlePublishMessage = this.handlePublishMessage
+    server.handlePublishMessage = this.handlePublishMessage;
     server.handlePublishMessage();
     process.on('SIGINT', () => {
       server.sids.forEach((value, key) => {
-        value.forEach(value => {
+        value.forEach((value) => {
           redisData.srem(value, key);
-        })
-      })
+        });
+      });
       process.exit();
-    })
+    });
   }
 
   async joinRoom(clientId: string, roomId: string) {
@@ -64,7 +64,10 @@ export class ExtensionWebSocketServer {
     return {
       emit: (event: string, message: string) => {
         if (this.rooms.has(roomId)) {
-          this.redisData.publish(`room:${roomId}`, JSON.stringify({ event, message }));
+          this.redisData.publish(
+            `room:${roomId}`,
+            JSON.stringify({ event, message }),
+          );
         }
       },
     };
@@ -73,10 +76,10 @@ export class ExtensionWebSocketServer {
   async subscribe(channel: string) {
     await this.redisSubscribe.subscribe(channel, (error, count) => {
       if (error) {
-        Logger.log('구독 오류')
+        Logger.log('구독 오류');
       }
-      Logger.log(`구독 성공: ${channel}, 현재 구독 중인 채널 수: ${count}`)
-    })
+      Logger.log(`구독 성공: ${channel}, 현재 구독 중인 채널 수: ${count}`);
+    });
   }
 
   handlePublishMessage() {
@@ -87,13 +90,11 @@ export class ExtensionWebSocketServer {
         if (this.rooms.has(roomId)) {
           const room = this.rooms.get(roomId);
           room.forEach((clientId) => {
-            this.clientMap
-              .get(clientId)
-              .send(JSON.stringify(message));
+            this.clientMap.get(clientId).send(JSON.stringify(message));
           });
         }
       }
-    })
+    });
   }
 
   async unSubscribe(channel: string) {

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
@@ -50,7 +50,7 @@ export class ExtensionWebSocketServer {
     if (this.rooms.has(roomId)) {
       const curRoom = this.rooms.get(roomId);
       curRoom.delete(clientId);
-      this.redisData.srem(roomId, clientId);
+      await this.redisData.srem(roomId, clientId);
       if (curRoom.size === 0) {
         this.unSubscribe(`room:${roomId}`);
       }

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
@@ -1,50 +1,103 @@
+import { Redis } from 'ioredis';
 import { WetriServer, WetriWebSocket } from '../types/custom-websocket.type';
+import { Logger } from '@nestjs/common';
 
 export class ExtensionWebSocketServer {
   rooms: Map<string, Set<string>>;
   sids: Map<string, Set<string>>;
   clientMap: Map<string, WetriWebSocket>;
-  constructor(server: WetriServer) {
+  redisData: Redis;
+  redisSubscribe: Redis;
+  constructor(server: WetriServer, redisData: Redis, redisSubscribe: Redis) {
     server.rooms = new Map<string, Set<string>>();
     server.sids = new Map<string, Set<string>>();
     server.clientMap = new Map<string, WetriWebSocket>();
+    server.redisData = redisData;
+    server.redisSubscribe = redisSubscribe;
     server.joinRoom = this.joinRoom;
     server.leaveRoom = this.leaveRoom;
     server.to = this.to;
+    server.subscribe = this.subscribe;
+    server.unSubscribe = this.unSubscribe;
+    server.handlePublishMessage = this.handlePublishMessage
+    server.handlePublishMessage();
+    process.on('SIGINT', () => {
+      server.sids.forEach((value, key) => {
+        value.forEach(value => {
+          redisData.srem(value, key);
+        })
+      })
+      process.exit();
+    })
   }
 
-  joinRoom(clientId: string, roomName: string) {
-    if (!this.rooms.has(roomName)) {
-      this.rooms.set(roomName, new Set());
+  async joinRoom(clientId: string, roomId: string) {
+    if (!this.rooms.has(roomId)) {
+      this.rooms.set(roomId, new Set());
+    }
+    if (this.rooms.get(roomId).size === 0) {
+      this.subscribe(`room:${roomId}`);
     }
     if (!this.sids.has(clientId)) {
       this.sids.set(clientId, new Set());
     }
-    this.rooms.get(roomName).add(clientId);
-    this.sids.get(clientId).add(roomName);
+    this.rooms.get(roomId).add(clientId);
+    this.sids.get(clientId).add(roomId);
+    await this.redisData.sadd(roomId, clientId);
   }
 
-  leaveRoom(clientId: string, roomName: string) {
-    if (this.rooms.has(roomName)) {
-      this.rooms.get(roomName).delete(clientId);
+  async leaveRoom(clientId: string, roomId: string) {
+    if (this.rooms.has(roomId)) {
+      const curRoom = this.rooms.get(roomId);
+      curRoom.delete(clientId);
+      this.redisData.srem(roomId, clientId);
+      if (curRoom.size === 0) {
+        this.unSubscribe(`room:${roomId}`);
+      }
     }
     if (this.sids.has(clientId)) {
-      this.sids.get(clientId).delete(roomName);
+      this.sids.get(clientId).delete(roomId);
     }
   }
 
-  to(roomName: string) {
+  to(roomId: string) {
     return {
       emit: (event: string, message: string) => {
-        if (this.rooms.has(roomName)) {
-          const room = this.rooms.get(roomName);
-          room.forEach((clientId) => {
-            this.clientMap
-              .get(clientId)
-              .send(JSON.stringify({ event, message }));
-          });
+        if (this.rooms.has(roomId)) {
+          this.redisData.publish(`room:${roomId}`, JSON.stringify({ event, message }));
         }
       },
     };
+  }
+
+  async subscribe(channel: string) {
+    await this.redisSubscribe.subscribe(channel, (error, count) => {
+      if (error) {
+        Logger.log('구독 오류')
+      }
+      Logger.log(`구독 성공: ${channel}, 현재 구독 중인 채널 수: ${count}`)
+    })
+  }
+
+  handlePublishMessage() {
+    this.redisSubscribe.on('message', (channel, message) => {
+      const chSplit = channel.split(':');
+      if (chSplit.length === 2) {
+        const roomId = chSplit[1];
+        if (this.rooms.has(roomId)) {
+          const room = this.rooms.get(roomId);
+          room.forEach((clientId) => {
+            this.clientMap
+              .get(clientId)
+              .send(JSON.stringify(message));
+          });
+        }
+      }
+    })
+  }
+
+  async unSubscribe(channel: string) {
+    await this.redisSubscribe.unsubscribe(channel);
+    Logger.log(`구독 취소됨: ${channel}`);
   }
 }

--- a/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
+++ b/BackEnd/src/live-workouts/events/extensions/extensionWebSocketServer.ts
@@ -21,7 +21,7 @@ export class ExtensionWebSocketServer {
     server.unSubscribe = this.unSubscribe;
     server.handlePublishMessage = this.handlePublishMessage;
     server.handlePublishMessage();
-    process.on('SIGINT', () => {
+    process.on('exit', () => {
       server.sids.forEach((value, key) => {
         value.forEach(async (value) => {
           await redisData.srem(value, key);
@@ -29,6 +29,9 @@ export class ExtensionWebSocketServer {
       });
       process.exit();
     });
+    process.on('SIGINT', () => process.exit());
+    process.on('SIGTERM', () => process.exit());
+    process.on('uncaughtException', () => process.exit());
   }
 
   async joinRoom(clientId: string, roomId: string) {

--- a/BackEnd/src/live-workouts/events/types/custom-websocket.type.ts
+++ b/BackEnd/src/live-workouts/events/types/custom-websocket.type.ts
@@ -1,12 +1,18 @@
+import { Redis } from 'ioredis';
 import * as WebSocket from 'ws';
 
 export interface WetriServer extends WebSocket.Server {
   clientMap: Map<string, WetriWebSocket>;
   rooms: Map<string, Set<string>>;
   sids: Map<string, Set<string>>;
+  redisData: Redis;
+  redisSubscribe: Redis;
   joinRoom: (clientId: string, roomName: string) => void;
   leaveRoom: (clientId: string, roomName: string) => void;
   to: (roomName: string) => { emit: (event: string, message: string) => void };
+  subscribe: (channel: string) => void;
+  unSubscribe: (channel: string) => void;
+  handlePublishMessage: () => void;
 }
 
 export interface WetriWebSocket extends WebSocket {

--- a/BackEnd/src/live-workouts/events/types/custom-websocket.type.ts
+++ b/BackEnd/src/live-workouts/events/types/custom-websocket.type.ts
@@ -9,7 +9,7 @@ export interface WetriServer extends WebSocket.Server {
   redisSubscribe: Redis;
   joinRoom: (clientId: string, roomName: string) => void;
   leaveRoom: (clientId: string, roomName: string) => void;
-  to: (roomName: string) => { emit: (event: string, message: string) => void };
+  to: (roomName: string) => { emit: (event: string, message: string, issuedClientId?: string) => void };
   subscribe: (channel: string) => void;
   unSubscribe: (channel: string) => void;
   handlePublishMessage: () => void;

--- a/BackEnd/src/live-workouts/matches/matches.module.ts
+++ b/BackEnd/src/live-workouts/matches/matches.module.ts
@@ -7,11 +7,7 @@ import { ProfilesModule } from '../../profiles/profiles.module';
 import { AuthService } from '../../auth/auth.service';
 
 @Module({
-  imports: [
-    JwtModule.register({}),
-    UsersModule,
-    ProfilesModule,
-  ],
+  imports: [JwtModule.register({}), UsersModule, ProfilesModule],
   controllers: [MatchesController],
   providers: [MatchesService, AuthService],
 })

--- a/BackEnd/src/live-workouts/matches/matches.module.ts
+++ b/BackEnd/src/live-workouts/matches/matches.module.ts
@@ -5,14 +5,9 @@ import { JwtModule } from '@nestjs/jwt';
 import { UsersModule } from '../../users/users.module';
 import { ProfilesModule } from '../../profiles/profiles.module';
 import { AuthService } from '../../auth/auth.service';
-import { RedisModule } from '@songkeys/nestjs-redis';
-import { RedisConfigService } from '../../config/redis.config';
 
 @Module({
   imports: [
-    RedisModule.forRootAsync({
-      useClass: RedisConfigService,
-    }),
     JwtModule.register({}),
     UsersModule,
     ProfilesModule,

--- a/BackEnd/src/live-workouts/matches/matches.service.spec.ts
+++ b/BackEnd/src/live-workouts/matches/matches.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRedisToken } from '@songkeys/nestjs-redis';
 import { MatchesService } from './matches.service';
 import { Profile } from '../../profiles/entities/profiles.entity';
 import { RandomMatchDto } from './dto/random-match.dto';
@@ -36,7 +35,7 @@ describe('MatchesService', () => {
       providers: [
         MatchesService,
         {
-          provide: getRedisToken('default'),
+          provide: 'DATA_REDIS',
           useValue: {
             rpush,
             lrem,

--- a/BackEnd/src/live-workouts/matches/matches.service.ts
+++ b/BackEnd/src/live-workouts/matches/matches.service.ts
@@ -1,5 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { InjectRedis } from '@songkeys/nestjs-redis';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Redis } from 'ioredis';
 import { CreateMatchDto } from './dto/create-match.dto';
 import { Profile } from '../../profiles/entities/profiles.entity';
@@ -23,7 +22,7 @@ import {
 export class MatchesService {
   private readonly logger: Logger = new Logger(MatchesService.name);
 
-  constructor(@InjectRedis() private readonly redis: Redis) {}
+  constructor(@Inject('DATA_REDIS') private readonly redis: Redis) {}
   async startMatch(
     profile: Profile,
     createMatchDto: CreateMatchDto,


### PR DESCRIPTION
## 고민, 과정, 근거 💬
client.id는 유저의 publicId를 뜻합니다. 
client: WeTriWebSocket -> WebSocket을 확장한 custom socket

기존에는 room을 서버내에서만 저장하고 있었습니다. 
이렇게 하면 문제점은 여러 서버간의 존재하는 room에 브로드캐스트(room에 있는 모든 유저에게 메시지 전송)를 하지 못합니다.
그래서 이 부분을 redis DB, redis pub/sub을 이용해서 구현했습니다.
![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/89844585/c13609d2-57d6-4eb5-9a48-5a0e6bf9ec4b)
이런 구조라고 생각하시면 됩니다.

그래서 전체적인 흐름을 말씀드리면 소켓에 연결할 때는 매칭 후이기 때문에 자신이 들어갈 roomId를 알고 있습니다. 
이 roomId를 전달해주면 서버에서는 `client.join(roomId);` 코드를 실행합니다. 
이 코드는 서버내 `rooms: Map<string, Set<string>>`에 key에 roomId를 value에 publicId를 저장합니다.
그리고 redis room에도 똑같은 구조로 저장해줍니다. 여기서 현재 서버내 roomId에 해당하는 방에 자신이 처음 들어갔다면 `room:roomId` 채널을 구독합니다. 이후 해당 채널에 메시지가 발행되면 channel에 roomId를 가져와서 그 방에 user에게 send 하는 용도로 사용됩니다.

`client.leave(roomId);` 이 코드는 roomId에 해당하는 room을 나갑니다. 서버내 룸도 나가고, redis 룸도 나갑니다. 
그리고 방에 자신이 마지막으로 나갔다면 `room:roomId` 채널을 구독 취소 해줍니다. 그러면 더 이상 해당 채널에서 발행되는 메시지는 받지 않습니다.

`this.server.to(roomId).emit(event, message, issuedClientId?);` 이 코드는 room에 브로드캐스트 하는 코드입니다. 이 함수에서 `room:roomId` 채널에 메시지를 발행합니다. 그러면 구독한 클라이언트(redis 입장에서 클라이언트는 서버를 뜻함)는 이 메시지를 받고 서버에 저장되어 있는 룸에 유저에게 JSON.stringify(message)를 보냅니다. 그러면 모든 room에 있는 모든 유저는 message를 받게 됩니다.
마지막 파라미터는 `issuedClientId`인데 이 파리미터의 clientId를 넣으면 그 client를 제외하고 브로드캐스트합니다. ( client.to().emit();를 위한 파라미터입니다. )

`client.to(roomId).emit(event, message);` 이 코드는 roomId에 보내는 유저를 제외하고 브로드캐스트합니다.

client가 연결이 끊어지면 client.on('close') 이벤트가 발생합니다. 
여기 내부에서는 client.leave를 사용해서 참여한 모든 방을 빠져나옵니다.

server가 종료되면 process.on('exit') 이벤트가 발생합니다.
여기 내부에서는 server의 모든 유저가 모든 방을 빠져나옵니다.
 
<br/><br/>

## References 📋
https://github.com/freeserver1191/ioredis-translation,
https://inpa.tistory.com/entry/REDIS-%F0%9F%93%9A-PUBSUB-%EA%B8%B0%EB%8A%A5-%EC%86%8C%EA%B0%9C-%EC%B1%84%ED%8C%85-%EA%B5%AC%EB%8F%85-%EC%95%8C%EB%A6%BC,
https://socket.io/docs/v4/redis-adapter/,
https://resilient-923.tistory.com/402

<br/><br/>

---

- Closed: #158 
