### PR TITLE
[GWL-162] Trinet 소켓 Providable 추가 + 테스트 코드 추가

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/AScene/ViewController/AViewController.swift
+++ b/iOS/Projects/App/WeTri/Sources/AScene/ViewController/AViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class AViewController: UITabBarController {
+class AViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -12,13 +12,15 @@ import UIKit
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
+  private var coordinating: AppCoordinating?
 
   func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
     guard let windowScene = scene as? UIWindowScene else { return }
     let navigationController = UINavigationController()
     window = UIWindow(windowScene: windowScene)
     window?.rootViewController = navigationController
-    let coordinator = RecordFeatureCoordinator(navigationController: navigationController)
+    let coordinator = AppCoordinator(navigationController: navigationController)
+    coordinating = coordinator
     coordinator.start()
     window?.makeKeyAndVisible()
   }

--- a/iOS/Projects/App/WeTri/Sources/CScene/ViewController/CViewController.swift
+++ b/iOS/Projects/App/WeTri/Sources/CScene/ViewController/CViewController.swift
@@ -6,11 +6,182 @@
 //  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
 //
 
+import Combine
+import Log
+import Trinet
 import UIKit
 
-class CViewController: UITabBarController {
+// MARK: - ParticipantsCodable
+
+struct ParticipantsCodable: Codable {
+  let id: UUID
+  let nickname: String
+  let message: String
+
+  init(message: String) {
+    id = .init()
+    self.message = message
+    nickname = "MyNickname"
+  }
+}
+
+// MARK: - CViewController
+
+final class CViewController: UIViewController {
+  private let returnSubject = PassthroughSubject<String, Never>()
+  private let repository = TestRepository(session: URLSession.shared)
+  private var subscriptions = Set<AnyCancellable>()
+
+  private let textField = UITextField()
+
+  private let textView: UITextView = .init()
+
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .red
+
+    textView.isUserInteractionEnabled = false
+    view.addSubview(textField)
+    view.addSubview(textView)
+    textField.placeholder = "입력해주세요."
+    textField.borderStyle = .roundedRect
+    textField.delegate = self
+
+    textView.textColor = .white
+    textView.backgroundColor = .black
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textView.translatesAutoresizingMaskIntoConstraints = false
+    view.backgroundColor = .white
+    let safeArea = view.safeAreaLayoutGuide
+    let recognizer = UITapGestureRecognizer(target: self, action: #selector(tapped))
+    view.addGestureRecognizer(recognizer)
+    NSLayoutConstraint.activate(
+      [
+        textField.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: 20),
+        textField.centerXAnchor.constraint(equalTo: safeArea.centerXAnchor),
+        textField.widthAnchor.constraint(equalToConstant: 240),
+        textField.heightAnchor.constraint(equalToConstant: 40),
+
+        textView.topAnchor.constraint(equalTo: safeArea.centerYAnchor),
+        textView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+        textView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+        textView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+      ]
+    )
+    bind()
   }
+
+  func bind() {
+    returnSubject
+      .flatMap(repository.sendMyHealth(healthData:))
+      .sink { _ in
+        Log.make().error("Completion!!!!!!")
+      } receiveValue: { _ in
+        Log.make().debug("Yay! Send successfully!")
+      }
+      .store(in: &subscriptions)
+
+    repository.fetchParticipantsRealTime()
+      .receive(on: RunLoop.main)
+      .sink { _ in
+        Log.make().error("Socket Receive Completion!!!!")
+      } receiveValue: { [weak self] dataString in
+        self?.textView.text = [self!.textView.text + dataString].joined(separator: "\n")
+        Log.make().debug("\(dataString)")
+      }
+      .store(in: &subscriptions)
+  }
+
+  @objc
+  private func tapped() {
+    textField.resignFirstResponder()
+  }
+}
+
+// MARK: UITextFieldDelegate
+
+extension CViewController: UITextFieldDelegate {
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    returnSubject.send(textField.text!)
+
+    textField.text = ""
+    return true
+  }
+}
+
+// MARK: - TestRepositoryRepresentable
+
+protocol TestRepositoryRepresentable {
+  func fetchParticipantsRealTime() -> AnyPublisher<String, Error>
+  func sendMyHealth(healthData: String) -> AnyPublisher<Bool, Error>
+}
+
+// MARK: - TestRepository
+
+struct TestRepository {
+  private let provider: TNSocketProvider<TestEndPoint>
+
+  private var task: Task<Void, Error>?
+
+  private let subject: PassthroughSubject<String, Error> = .init()
+
+  init(session: URLSessionWebSocketProtocol) {
+    provider = .init(session: session, endPoint: .init())
+    task = receiveParticipantsData()
+  }
+
+  private func receiveParticipantsData() -> Task<Void, Error> {
+    return Task {
+      Log.make(with: .network).debug("receive Ready")
+      while let data = try await provider.receive() {
+        switch data {
+        case let .string(string):
+          Log.make(with: .network).debug("received \(string)")
+          subject.send(string)
+        default:
+          fatalError("절대 여기 와서는 안 됨")
+        }
+      }
+      Log.make().fault("You can't enter this line")
+    }
+  }
+}
+
+// MARK: TestRepositoryRepresentable
+
+extension TestRepository: TestRepositoryRepresentable {
+  func fetchParticipantsRealTime() -> AnyPublisher<String, Error> {
+    subject.eraseToAnyPublisher()
+  }
+
+  func sendMyHealth(healthData: String) -> AnyPublisher<Bool, Error> {
+    Future { promise in
+      Task {
+        do {
+          try await provider.send(model: ParticipantsCodable(message: healthData))
+          promise(.success(true))
+        } catch {
+          promise(.failure(error))
+        }
+      }
+    }
+    .eraseToAnyPublisher()
+  }
+}
+
+// MARK: - TestEndPoint
+
+struct TestEndPoint: TNEndPoint {
+  let baseURL: String = Bundle.main.infoDictionary?["SocketURL"] as? String ?? ""
+
+  let path: String = ""
+
+  let method: TNMethod = .get
+
+  let query: Encodable? = nil
+
+  let body: Encodable? = nil
+
+  let headers: TNHeaders = [
+    .authorization(bearer: ""),
+  ]
 }

--- a/iOS/Projects/Core/Network/Sources/MockWebSocketSession.swift
+++ b/iOS/Projects/Core/Network/Sources/MockWebSocketSession.swift
@@ -1,0 +1,44 @@
+//
+//  MockWebSocketSession.swift
+//  Trinet
+//
+//  Created by 홍승현 on 11/29/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - MockWebSocketTask
+
+public final class MockWebSocketTask: WebSocketTaskProtocol {
+  private var sentMessage: URLSessionWebSocketTask.Message?
+  private var receiveContinuation: CheckedContinuation<URLSessionWebSocketTask.Message, Never>?
+
+  public func send(_ message: URLSessionWebSocketTask.Message) async throws {
+    sentMessage = message
+    receiveContinuation?.resume(returning: message)
+  }
+
+  public func receive() async throws -> URLSessionWebSocketTask.Message {
+    if let receivedMessage = sentMessage {
+      sentMessage = nil
+      return receivedMessage
+    }
+
+    return await withCheckedContinuation { continuation in
+      receiveContinuation = continuation
+    }
+  }
+
+  public func resume() {}
+}
+
+// MARK: - MockWebSocketSession
+
+public struct MockWebSocketSession: URLSessionWebSocketProtocol {
+  var webSocketTask: MockWebSocketTask = .init()
+
+  public func webSocketTask(with _: URLRequest) -> WebSocketTaskProtocol {
+    return webSocketTask
+  }
+}

--- a/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
+++ b/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
@@ -1,0 +1,40 @@
+//
+//  TNSocketProvider.swift
+//  Trinet
+//
+//  Created by 홍승현 on 11/29/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import Foundation
+import OSLog
+
+// MARK: - TNSocketProvidable
+
+public protocol TNSocketProvidable {
+  func send<Model: Codable>(model: Model) async throws
+  func receive() async throws -> URLSessionWebSocketTask.Message?
+}
+
+// MARK: - TNSocketProvider
+
+public struct TNSocketProvider<EndPoint: TNEndPoint>: TNSocketProvidable {
+  private let session: URLSessionWebSocketProtocol
+  private var task: WebSocketTaskProtocol?
+  private let jsonEncoder: JSONEncoder = .init()
+
+  public init(session: URLSessionWebSocketProtocol = URLSession.shared, endPoint: EndPoint) {
+    self.session = session
+    task = try? session.webSocketTask(with: endPoint.request())
+    task?.resume()
+  }
+
+  public func send(model: some Codable) async throws {
+    try await task?.send(.data(jsonEncoder.encode(model)))
+  }
+
+  public func receive() async throws -> URLSessionWebSocketTask.Message? {
+    return try await task?.receive()
+  }
+}

--- a/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
+++ b/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
@@ -31,10 +31,21 @@ public struct TNSocketProvider<EndPoint: TNEndPoint>: TNSocketProvidable {
   }
 
   public func send(model: some Codable) async throws {
-    try await task?.send(.data(jsonEncoder.encode(model)))
+    let frame = WebSocketFrame(data: model)
+    try await task?.send(.data(jsonEncoder.encode(frame)))
   }
 
   public func receive() async throws -> URLSessionWebSocketTask.Message? {
     return try await task?.receive()
+  }
+}
+
+private struct WebSocketFrame<T: Codable>: Codable {
+  let event: String
+  let data: T
+
+  init(event: String = "events", data: T) {
+    self.event = event
+    self.data = data
   }
 }

--- a/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
+++ b/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
@@ -44,7 +44,7 @@ struct WebSocketFrame<T: Codable>: Codable {
   let event: String
   let data: T
 
-  init(event: String = "events", data: T) {
+  init(event: String = "workout_session", data: T) {
     self.event = event
     self.data = data
   }

--- a/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
+++ b/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
@@ -40,6 +40,8 @@ public struct TNSocketProvider<EndPoint: TNEndPoint>: TNSocketProvidable {
   }
 }
 
+// MARK: - WebSocketFrame
+
 private struct WebSocketFrame<T: Codable>: Codable {
   let event: String
   let data: T

--- a/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
+++ b/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
 //
 
-import Combine
 import Foundation
-import OSLog
 
 // MARK: - TNSocketProvidable
 

--- a/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
+++ b/iOS/Projects/Core/Network/Sources/TNSocketProvider.swift
@@ -40,7 +40,7 @@ public struct TNSocketProvider<EndPoint: TNEndPoint>: TNSocketProvidable {
 
 // MARK: - WebSocketFrame
 
-private struct WebSocketFrame<T: Codable>: Codable {
+struct WebSocketFrame<T: Codable>: Codable {
   let event: String
   let data: T
 

--- a/iOS/Projects/Core/Network/Sources/URLSessionWebSocketProtocol.swift
+++ b/iOS/Projects/Core/Network/Sources/URLSessionWebSocketProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  URLSessionWebSocketProtocol.swift
+//  Trinet
+//
+//  Created by 홍승현 on 11/29/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - URLSessionWebSocketProtocol
+
+public protocol URLSessionWebSocketProtocol {
+  func webSocketTask(with request: URLRequest) -> WebSocketTaskProtocol
+}
+
+// MARK: - URLSession + URLSessionWebSocketProtocol
+
+extension URLSession: URLSessionWebSocketProtocol {
+  public func webSocketTask(with request: URLRequest) -> WebSocketTaskProtocol {
+    let socketTask: URLSessionWebSocketTask = webSocketTask(with: request)
+    return socketTask
+  }
+}

--- a/iOS/Projects/Core/Network/Sources/WebSocketTaskProtocol.swift
+++ b/iOS/Projects/Core/Network/Sources/WebSocketTaskProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  WebSocketTaskProtocol.swift
+//  Trinet
+//
+//  Created by 홍승현 on 11/29/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - WebSocketTaskProtocol
+
+public protocol WebSocketTaskProtocol {
+  func send(_ message: URLSessionWebSocketTask.Message) async throws
+
+  func receive() async throws -> URLSessionWebSocketTask.Message
+}
+
+// MARK: - URLSessionWebSocketTask + WebSocketTaskProtocol
+
+extension URLSessionWebSocketTask: WebSocketTaskProtocol {}

--- a/iOS/Projects/Core/Network/Sources/WebSocketTaskProtocol.swift
+++ b/iOS/Projects/Core/Network/Sources/WebSocketTaskProtocol.swift
@@ -14,6 +14,8 @@ public protocol WebSocketTaskProtocol {
   func send(_ message: URLSessionWebSocketTask.Message) async throws
 
   func receive() async throws -> URLSessionWebSocketTask.Message
+
+  func resume()
 }
 
 // MARK: - URLSessionWebSocketTask + WebSocketTaskProtocol

--- a/iOS/Projects/Core/Network/Tests/SessionWebSocketProtocolTests.swift
+++ b/iOS/Projects/Core/Network/Tests/SessionWebSocketProtocolTests.swift
@@ -1,0 +1,56 @@
+//
+//  SessionWebSocketProtocolTests.swift
+//  TrinetTests
+//
+//  Created by 홍승현 on 11/29/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+@testable import Trinet
+
+import XCTest
+
+final class SessionWebSocketProtocolTests: XCTestCase {
+  private var mockSession: MockWebSocketSession?
+  private var socketProvider: TNSocketProvider<MockEndPoint>?
+
+  struct TestModel: Codable, Equatable {
+    var id: UUID = .init()
+    var profileImage: String = "https://hello.world"
+    var nickname: String = "NickName"
+    var message: String = ""
+  }
+
+  override func setUp() {
+    super.setUp()
+    let mockSession = MockWebSocketSession()
+    self.mockSession = mockSession
+    socketProvider = TNSocketProvider(session: mockSession, endPoint: MockEndPoint())
+  }
+
+  override func tearDown() {
+    mockSession = nil
+    socketProvider = nil
+    super.tearDown()
+  }
+
+  func testSendAndReceive() async throws {
+    // arrange
+    let testModel = TestModel()
+
+    // act
+    Task {
+      try await self.socketProvider?.send(model: testModel)
+    }
+
+    // Receive 메서드를 비동기로 호출하여 결과 검증
+    let receivedMessage = try await socketProvider?.receive()
+    guard case let .data(data) = receivedMessage else {
+      XCTFail("Received message is not of type .data")
+      return
+    }
+
+    let receivedModel = try JSONDecoder().decode(WebSocketFrame<TestModel>.self, from: data)
+    XCTAssertEqual(receivedModel.data, testModel, "Received model does not match sent model")
+  }
+}

--- a/iOS/Tuist/ProjectDescriptionHelpers/Target+Templates.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/Target+Templates.swift
@@ -35,6 +35,7 @@ public extension [Target] {
 
     let mergedInfoPlist: [String: Plist.Value] = [
       "BaseURL": "$(BASE_URL)",
+      "SocketURL": "$(SOCKET_URL)",
       "UILaunchStoryboardName": "LaunchScreen",
       "UIApplicationSceneManifest": [
         "UIApplicationSupportsMultipleScenes": false,
@@ -122,7 +123,7 @@ public extension [Target] {
     resources: ResourceFileElements? = nil
   ) -> [Target] {
 
-    let mergedInfoPlist: [String: Plist.Value] = ["BaseURL": "$(BASE_URL)"].merging(infoPlist) { _, new in
+    let mergedInfoPlist: [String: Plist.Value] = ["BaseURL": "$(BASE_URL)", "SocketURL": "$(SOCKET_URL)"].merging(infoPlist) { _, new in
       new
     }
 
@@ -203,7 +204,7 @@ public extension [Target] {
     settings: Settings? = nil
   ) -> [Target] {
     
-    let mergedInfoPlist: [String: Plist.Value] = ["BaseURL": "$(BASE_URL)"].merging(infoPlist) { _, new in
+    let mergedInfoPlist: [String: Plist.Value] = ["BaseURL": "$(BASE_URL)", "SocketURL": "$(SOCKET_URL)"].merging(infoPlist) { _, new in
       new
     }
 


### PR DESCRIPTION
## Screenshots 📸

> [!Note]
>
> 해당 브랜치에서 세 번째 탭에 테스트 코드를 넣어두었습니다. 제 브랜치로 이동하시면 바로 소켓 테스트를 하실 수 있습니다!

|iPhone과 postman 간 소켓 통신 테스트|
|:-:|
|![Screen Recording 2023-11-29 at 9 23 28 PM](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/b6a4158b-357d-4bb8-b31c-24bf49534d3c)|
|생각한 구조|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/ddb9be6c-cf92-45f2-89d0-a5079abe87a6)|

<br/><br/>

## 고민, 과정, 근거 💬

같이하기일 경우 다른 사람들의 데이터를 소켓으로 받아와서 업데이트를 해주어야했고, 혼자하기인 경우에는 소켓통신의 필요 없이 스스로 UI를 업데이트해주어야합니다. 이 분기처리를 어떻게 할지 고민한 결과, URLSession에서 사용되는 SocketTask를 protocol로 추상화하기로 결정했습니다.

### 이유는요..?

지난 번에 논의했던 구조를 일부 가져왔습니다. 레포지토리에서 `혼자하기`인 경우 자체적으로 데이터를 리턴하고, `함께하기`인 경우 데이터로 전달하는 과정을 갖고 있는데요.

![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/3ac67cee-fbda-4943-9aa5-4423d561eeee)

Repository에서 운동 모드를 인지하고 직접 나누는 행위에 대해 고민을 해보게 되었어요.
어찌보면 Repository에서 분기가 일어나는 로직이다보니, 흐름에 문제가 생겼을 때 빠르게 확인할 수 있지는 않을 것 같다는 결론을 내리게 되었습니다. 신경써주어야하는 곳이 UseCase외에 한 곳이 더 늘어나게 된 셈이니까요. 무엇보다 Repository가 분기처리를 하는 것은 방향성에 맞지 않다고 생각했어요.

![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/a4cad1d4-b4c4-4761-ba48-97ad65158abd)

그래서 제가 생각한 방법은 Socket Provider가 Session을 가지고 소켓 통신을 진행하는 흐름을 그대로 가져가되, 혼자하기 일 때는 Mock을 설정하여 실제로 통신이 되고있는 것처럼 속이는 것이에요. 그러면 분기 처리 없이 흐름을 그대로 유지 할 수 있으니까요.



<br/><br/>

## References 📋

1. [Advances in Networking, Part 1](https://developer.apple.com/wwdc19/712?time=1810)

---

- Closed: #162
