### PR TITLE
[GWL-166] Workouts API에 icon 이미지 컬럼 추가, Swagger 수정

### DIFF
--- a/BackEnd/src/workouts/dto/workout-response.dto.ts
+++ b/BackEnd/src/workouts/dto/workout-response.dto.ts
@@ -12,10 +12,23 @@ export const WorkoutResDtoSwagger = () => {
     example: {
       code: null,
       errorMessage: null,
-      data: {
-        id: 1,
-        name: '달리기',
-      },
+      data: [
+        {
+          id: 1,
+          name: '달리기',
+          icon: 'figure.outdoor.a',
+        },
+        {
+          id: 2,
+          name: '수영',
+          icon: 'figure.outdoor.b',
+        },
+        {
+          id: 3,
+          name: '사이클',
+          icon: 'figure.outdoor.c',
+        },
+      ]
     },
   };
 };

--- a/BackEnd/src/workouts/entities/workout.entity.ts
+++ b/BackEnd/src/workouts/entities/workout.entity.ts
@@ -20,6 +20,14 @@ export class Workout {
   @IsString()
   name: string;
 
+  @ApiProperty({
+    example: '운동 종류의 아이콘 경로 문자열',
+    description: 'figure.outdoor.workout',
+  })
+  @Column()
+  @IsString()
+  icon: string;
+
   @OneToMany(() => Record, (record) => record.workout)
   records: Record[];
 }

--- a/BackEnd/src/workouts/workouts.service.spec.ts
+++ b/BackEnd/src/workouts/workouts.service.spec.ts
@@ -10,9 +10,9 @@ describe('WorkoutsService', () => {
 
   beforeEach(async () => {
     const mockWorkouts: Workout[] = [
-      { id: 1, name: '달리기' } as Workout,
-      { id: 2, name: '수영' } as Workout,
-      { id: 3, name: '사이클' } as Workout,
+      { id: 1, name: '달리기', icon: 'a' } as Workout,
+      { id: 2, name: '수영', icon: 'b' } as Workout,
+      { id: 3, name: '사이클', icon: 'c' } as Workout,
     ];
 
     mockRepository = {
@@ -34,9 +34,9 @@ describe('WorkoutsService', () => {
 
   it('서비스의 findAllworkouts는 목 데이터를 동일하게 리턴해야한다.', async () => {
     expect(await service.findAllWorkouts()).toEqual([
-      { id: 1, name: '달리기' } as Workout,
-      { id: 2, name: '수영' } as Workout,
-      { id: 3, name: '사이클' } as Workout,
+      { id: 1, name: '달리기', icon: 'a' } as Workout,
+      { id: 2, name: '수영', icon: 'b' } as Workout,
+      { id: 3, name: '사이클', icon: 'c' } as Workout,
     ]);
     expect(mockRepository.find).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Screenshots 📸

|Workouts|
|:-:|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/56383948/34a162e6-726c-4a93-a2ed-9c4d328a33e3)|

<br/>

- [x] Workouts API에 icon 이미지 컬럼 추가
- [x] Swagger 수정
- [x] 노션에 Workouts API 작성

<br/>

## 고민, 과정, 근거 💬

<br/>

- 다함님과의 소통으로 API의 마무리 도장을 쾅 찍었습니다.
- icon 스트링을 추가하고, 노션에 API를 작성했습니다!

<br/>

## References 📋


<br/><br/>

---

- Closed: #166 
