### PR TITLE
[GWL-174] Matches API nickname -> publicId로 수정

### DIFF
--- a/BackEnd/src/live-workouts/matches/dto/random-match.dto.ts
+++ b/BackEnd/src/live-workouts/matches/dto/random-match.dto.ts
@@ -27,19 +27,19 @@ export class RandomMatch {
 
   @IsString()
   @ApiProperty({ example: 'uuid' })
-  matchId?: string;
+  roomId?: string;
 
   @ApiProperty({
     example: [
       {
         nickname: 'nickname',
         publicId: 'profileImage',
-        etc: 'etc',
+        etc: '그 외 나머지 모든 컬럼',
       },
       {
         nickname: 'nickname',
         publicId: 'profileImage',
-        etc: 'etc',
+        etc: '그 외 나머지 모든 컬럼',
       },
     ],
   })

--- a/BackEnd/src/live-workouts/matches/matches.service.spec.ts
+++ b/BackEnd/src/live-workouts/matches/matches.service.spec.ts
@@ -59,7 +59,7 @@ describe('MatchesService', () => {
     let createMatchDto;
 
     beforeEach(() => {
-      profile = { nickname: 'TestUser' } as Profile;
+      profile = { publicId: 'TestUser' } as Profile;
       createMatchDto = { workoutId: 1 };
     });
 
@@ -98,8 +98,8 @@ describe('MatchesService', () => {
       const workoutId = 1;
       const waitingUsers = 2;
       const serializedUsers = [
-        JSON.stringify({ nickname: 'User1' }),
-        JSON.stringify({ nickname: 'User2' }),
+        JSON.stringify({ publicId: 'User1' }),
+        JSON.stringify({ publicId: 'User2' }),
       ];
       lrange.mockResolvedValue(serializedUsers);
 
@@ -160,7 +160,7 @@ describe('MatchesService', () => {
 
   describe('initMatch 메서드 검증', () => {
     it('닉네임과 운동 종류가 주어질 때, 실제로 리스트에서 제거 및 매칭에서 제거되는지 확인한다.', async () => {
-      const profile = { nickname: 'TestUser' } as Profile;
+      const profile = { publicId: 'TestUser' } as Profile;
       const workoutId = 1;
 
       await service['initMatch'](profile, workoutId);
@@ -170,7 +170,7 @@ describe('MatchesService', () => {
         0,
         JSON.stringify(profile),
       );
-      expect(del).toHaveBeenCalledWith(`userMatch:${profile.nickname}`);
+      expect(del).toHaveBeenCalledWith(`userMatch:${profile.publicId}`);
     });
   });
 });


### PR DESCRIPTION
## Screenshots 📸

|Matches|
|:-:|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/56383948/5c0f64eb-0daf-4b0d-abaa-d222ed0330f3)|

<br/>

- [x] Matches API에서 nickname을 publicId로 수정한다.
- [x] 노션 API를 작성한다.

<br/>

## 고민, 과정, 근거 💬

<br/>

- Matches API가 노션에 등록 되었습니다.

<br/>

## References 📋


<br/><br/>

---

- Closed: #174 
