### PR TITLE
[GWL-85] 서버 구조에 맞게 웹 소켓 연동

### DIFF
--- a/iOS/Projects/Core/Network/Sources/MockWebSocketSession.swift
+++ b/iOS/Projects/Core/Network/Sources/MockWebSocketSession.swift
@@ -26,7 +26,7 @@ public final class MockWebSocketTask<DataModel: Codable>: WebSocketTaskProtocol 
       guard let jsonString = String(data: jsonData, encoding: .utf8) else {
         throw MockWebSocketError.stringConversionFailed
       }
-      // string Message로 변환
+
       let stringMessage = URLSessionWebSocketTask.Message.string(jsonString)
       sentMessage = stringMessage
       receiveContinuation?.resume(returning: stringMessage)

--- a/iOS/Projects/Core/Network/Sources/MockWebSocketSession.swift
+++ b/iOS/Projects/Core/Network/Sources/MockWebSocketSession.swift
@@ -10,15 +10,30 @@ import Foundation
 
 // MARK: - MockWebSocketTask
 
-public final class MockWebSocketTask: WebSocketTaskProtocol {
+public final class MockWebSocketTask<DataModel: Codable>: WebSocketTaskProtocol {
   private var sentMessage: URLSessionWebSocketTask.Message?
   private var receiveContinuation: CheckedContinuation<URLSessionWebSocketTask.Message, Never>?
+  private let jsonEncoder: JSONEncoder = .init()
+  private let jsonDecoder: JSONDecoder = .init()
 
   public init() {}
 
   public func send(_ message: URLSessionWebSocketTask.Message) async throws {
-    sentMessage = message
-    receiveContinuation?.resume(returning: message)
+    switch message {
+    case let .data(data):
+      let socketFrame = try jsonDecoder.decode(WebSocketFrame<DataModel>.self, from: data)
+      let jsonData = try jsonEncoder.encode(socketFrame.data)
+      guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+        throw MockWebSocketError.stringConversionFailed
+      }
+      // string Message로 변환
+      let stringMessage = URLSessionWebSocketTask.Message.string(jsonString)
+      sentMessage = stringMessage
+      receiveContinuation?.resume(returning: stringMessage)
+    default:
+      sentMessage = message
+      receiveContinuation?.resume(returning: message)
+    }
   }
 
   public func receive() async throws -> URLSessionWebSocketTask.Message {
@@ -37,12 +52,18 @@ public final class MockWebSocketTask: WebSocketTaskProtocol {
 
 // MARK: - MockWebSocketSession
 
-public struct MockWebSocketSession: URLSessionWebSocketProtocol {
-  var webSocketTask: MockWebSocketTask = .init()
+public struct MockWebSocketSession<DataModel: Codable>: URLSessionWebSocketProtocol {
+  var webSocketTask: MockWebSocketTask<DataModel> = .init()
 
   public init() {}
 
   public func webSocketTask(with _: URLRequest) -> WebSocketTaskProtocol {
     return webSocketTask
   }
+}
+
+// MARK: - MockWebSocketError
+
+private enum MockWebSocketError: Error {
+  case stringConversionFailed
 }

--- a/iOS/Projects/Core/Network/Tests/SessionWebSocketProtocolTests.swift
+++ b/iOS/Projects/Core/Network/Tests/SessionWebSocketProtocolTests.swift
@@ -11,7 +11,7 @@
 import XCTest
 
 final class SessionWebSocketProtocolTests: XCTestCase {
-  private var mockSession: MockWebSocketSession?
+  private var mockSession: MockWebSocketSession<TestModel>?
   private var socketProvider: TNSocketProvider<MockEndPoint>?
 
   struct TestModel: Codable, Equatable {
@@ -23,7 +23,7 @@ final class SessionWebSocketProtocolTests: XCTestCase {
 
   override func setUp() {
     super.setUp()
-    let mockSession = MockWebSocketSession()
+    let mockSession = MockWebSocketSession<TestModel>()
     self.mockSession = mockSession
     socketProvider = TNSocketProvider(session: mockSession, endPoint: MockEndPoint())
   }

--- a/iOS/Projects/Core/Network/Tests/SessionWebSocketProtocolTests.swift
+++ b/iOS/Projects/Core/Network/Tests/SessionWebSocketProtocolTests.swift
@@ -43,14 +43,21 @@ final class SessionWebSocketProtocolTests: XCTestCase {
       try await self.socketProvider?.send(model: testModel)
     }
 
+    // assert
+
     // Receive 메서드를 비동기로 호출하여 결과 검증
     let receivedMessage = try await socketProvider?.receive()
-    guard case let .data(data) = receivedMessage else {
-      XCTFail("Received message is not of type .data")
+    guard case let .string(string) = receivedMessage else {
+      XCTFail("Received message is not of type .string")
       return
     }
 
-    let receivedModel = try JSONDecoder().decode(WebSocketFrame<TestModel>.self, from: data)
-    XCTAssertEqual(receivedModel.data, testModel, "Received model does not match sent model")
+    guard let jsonData = string.data(using: .utf8) else {
+      XCTFail("data cannot parse to data")
+      return
+    }
+
+    let receivedModel = try JSONDecoder().decode(TestModel.self, from: jsonData)
+    XCTAssertEqual(receivedModel, testModel, "Received model does not match sent model")
   }
 }

--- a/iOS/Projects/Features/Record/Sources/Domain/Entities/WorkoutRealTimeModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Domain/Entities/WorkoutRealTimeModel.swift
@@ -44,3 +44,19 @@ struct WorkoutHealthRealTimeModel: Codable {
   /// 현재 심박수
   let heartRate: Double?
 }
+
+// MARK: - WorkoutRealTimeModel + CustomStringConvertible
+
+extension WorkoutRealTimeModel: CustomStringConvertible {
+  var description: String {
+    return "id: \(id)\nroomID: \(roomID)\nnickname: \(nickname)\nhealth: \(health)"
+  }
+}
+
+// MARK: - WorkoutHealthRealTimeModel + CustomStringConvertible
+
+extension WorkoutHealthRealTimeModel: CustomStringConvertible {
+  var description: String {
+    return "distance: \(distance ?? 0)\ncalories: \(calories ?? 0)\nheartRate: \(heartRate ?? 0)"
+  }
+}

--- a/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
@@ -57,7 +57,7 @@ final class WorkoutSessionCoordinator: WorkoutSessionCoordinating {
     let healthRepository = HealthRepository()
 
     // TODO: 같이하기, 혼자하기 모드에 따라 session 주입을 다르게 해야합니다.
-    let socketRepository = WorkoutSocketRepository(session: MockWebSocketSession(), dependency: dependency)
+    let socketRepository = WorkoutSocketRepository(session: MockWebSocketSession<WorkoutRealTimeModel>(), dependency: dependency)
 
     let sessionUseCase = WorkoutSessionUseCase(
       healthRepository: healthRepository,

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/SessionParticipantCell.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/SessionParticipantCell.swift
@@ -190,7 +190,8 @@ final class SessionParticipantCell: UICollectionViewCell {
   }
 
   func configure(with model: WorkoutHealthRealTimeModel?) {
-    distanceLabel.text = "\(model?.distance ?? 0)"
+    // 소수점 세 자리까지만 표현
+    distanceLabel.text = "\(((model?.distance ?? 0) * 1000).rounded(.toNearestOrAwayFromZero) / 1000)m"
   }
 }
 

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
@@ -133,6 +133,11 @@ public final class WorkoutSessionViewController: UIViewController {
           self?.realTimeModelByID[model.id] = model.health
           var snapshot = self?.participantsDataSource?.snapshot()
           snapshot?.reconfigureItems([model.id])
+          if let snapshot {
+            self?.participantsDataSource?.apply(snapshot)
+          } else {
+            Log.make().error("snapshot이 생성되지 못했습니다. 헬스 데이터로 UI를 그리지 못합니다.")
+          }
         }
       }
       .store(in: &subscriptions)

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/SessionScene/WorkoutSessionViewController.swift
@@ -129,6 +129,7 @@ public final class WorkoutSessionViewController: UIViewController {
         case let .fetchMyHealthForm(myHealthForm):
           self?.healthData = myHealthForm
         case let .fetchParticipantsIncludedMySelf(model):
+          Log.make().debug("\(model)")
           self?.realTimeModelByID[model.id] = model.health
           var snapshot = self?.participantsDataSource?.snapshot()
           snapshot?.reconfigureItems([model.id])

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
@@ -44,7 +44,7 @@ final class WorkoutSessionContainerViewController: UIViewController {
   private let recordTimerLabel: UILabel = {
     let label = UILabel()
     label.font = .preferredFont(forTextStyle: .largeTitle)
-    label.text = "0분 0초"
+    label.text = "00분 00초"
     return label
   }()
 


### PR DESCRIPTION
## Screenshots 📸

|혼자하기 테스트|
|:-:|
|![RPReplay_Final1701502778](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/05e1d8d2-5216-46d3-9094-8ec5fd7586ce)|

<br/><br/>

## 고민, 과정, 근거 💬

MockWebSocketSession과 실서버와 동작을 동일하게 유지하기 위해서 테스트 코드를 실서버에서 오는 것과 동일하게 수정했고, 실패한 테스트를 성공시키기 위해 Session을 고쳐나갔습니다.

### 테스트는 무엇이 달랐나

![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/8b8ddd18-a499-4965-9634-5f3291fbd9ce)


`MockWebSocketTask`와 `URLSessionWebSocketTask`는 `URLSessionWebSocketTask.Message`를 보내거나(send) 받게(receive)되는 코드를 담고 있습니다. 이 때 `MockWebSocketTask`는 Message타입이 `data(_:)`타입이거나 `string(_:)`타입이면 그 타입을 그대로 `receive`에 넘기도록 구현해두었으나, 실서버에서는 `data(_:)`로 보냈을 때 `string(_:)`타입으로 들어오게됩니다.
그리고 `WebSocketFrame<T>`타입으로 전달하면, receive메서드로 받았을 때 `WebSocketFrame`이 벗겨진 **`T`** 타입이 들어오게 됩니다.

### 어떻게 해결했나

실제 코드에서는 TNSocketProvider에서 `WebSocketFrame`에 담을 모델을 encode하여 session에게 Data타입으로 요청을 보냅니다. MockSession은 MockWebSocketTask에게 이벤트를 전달하고, MockWebSocketTask는 `Data`타입을 `WebSocketFrame`을 벗겨내어 제네릭으로 감싸둔 모종의 `T` 타입을 `string(_:)` 메시지로 넘겨주어야했습니다.

그런데 Session과 Task는 제네릭 타입을 알지 못합니다. provider단에서 encoding된 Data를 넘겨주었기 때문입니다. 구체 타입을 알아야 Data타입을 Decoding하고 `WebSocketFrame`을 벗겨내어 원하는 구체타입으로 변환한 뒤 메시지로 넘겨줄 수 있기에, 다른 방법이 필요했습니다.

1. mock provider를 만들고 직접 모델을 string으로 변경하여 session에게 넘겨준다.
2. mock session과 task에 구체 타입으로 반환할 generic 타입을 선언하고, data타입을 받을 때마다 generic으로 받았던 타입으로 변환한 뒤 `receive`에게 제공한다.

첫 번째는 provider를 mock으로 만들어야 하고, 저희 구조에서 provider를 파라미터로 넘겨주는 작업은 없기에, 구조를 통일하고자 해결 방법으로 채택하지 않았습니다.
그래서 두 번째 방법으로 MockSession을 수정해서 테스트를 성공시켰는데요. SocketProvider이 전달할 model 타입과 MockWebSocketTask, MockWebSocketSession이 변환할 제네릭 타입이 동일해야 정상적으로 작동한다는 오점이 있습니다.
이 문제를 또 해결할 수 있다면 SocketProvider도 제네릭으로 설정하여 보낼 수 있는 타입을 제한하는 것인데요.. 우선 지금의 방법도  해결가능하기에 일단 PR을 올려봅니다. ㅎㅎ
만약 여러분께서 휴먼 에러가 발생할 염려가 있다고 판단되는 경우 MockWebSocketTask, MockWebSocketSession, TNSocketProvider를 하나의 제네릭 타입을 갖도록 수정한 뒤 리뷰 요청보내도록 하겠습니다.


---

- #85
