### PR TITLE
[GWL-176] Profile API를 구현한다.

### DIFF
--- a/BackEnd/public/index.html
+++ b/BackEnd/public/index.html
@@ -81,6 +81,7 @@
           >Download Week 2 App</a
         >
         <a href="itms-services://?action=download-manifest&amp;url=https://kr.object.ncloudstorage.com/wetri-ios-ipa/iOSweek3/manifest.plist" class="download-button week-3">Download Week 3 App</a>
+        <a href="itms-services://?action=download-manifest&amp;url=https://kr.object.ncloudstorage.com/wetri-ios-ipa/iOSweek4/manifest.plist" class="download-button week-4">Download Week 4 App</a>
       </section>
     </main>
     <footer>

--- a/BackEnd/src/auth/auth.service.ts
+++ b/BackEnd/src/auth/auth.service.ts
@@ -47,7 +47,9 @@ export class AuthService {
   }
 
   async registerWithUserIdAndProvider(signupInfo: SignupDto) {
-    if (await this.profilesService.existByNickname(signupInfo.nickname)) {
+    if (
+      await this.profilesService.validateProfileNickname(signupInfo.nickname)
+    ) {
       throw new NicknameDuplicateException();
     }
     const newUser = await this.usersService.createUser(signupInfo);
@@ -81,7 +83,7 @@ export class AuthService {
       return false;
     }
 
-    const profile = await this.profilesService.findByPublicId(decoded.sub);
+    const profile = await this.profilesService.getProfile(decoded.sub);
 
     if (!profile) {
       return false;

--- a/BackEnd/src/auth/dto/signup.dto.ts
+++ b/BackEnd/src/auth/dto/signup.dto.ts
@@ -8,6 +8,7 @@ class ProfileDto extends PickType(Profile, [
   'nickname',
   'gender',
   'birthdate',
+  'profileImage',
 ]) {}
 
 export class SignupDto extends IntersectionType(UserDto, ProfileDto) {

--- a/BackEnd/src/auth/guard/bearerToken.guard.ts
+++ b/BackEnd/src/auth/guard/bearerToken.guard.ts
@@ -26,7 +26,7 @@ export class BearerTokenGuard implements CanActivate {
 
     const decoded = await this.authService.verifyToken(token);
 
-    const profile = await this.profilesService.findByPublicId(decoded.sub);
+    const profile = await this.profilesService.getProfile(decoded.sub);
 
     const type = decoded.type;
 

--- a/BackEnd/src/images/images.module.ts
+++ b/BackEnd/src/images/images.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ImagesController } from './images.controller';
 import { ImagesService } from './images.service';
-import {AuthModule} from "../auth/auth.module";
-import {ProfilesModule} from "../profiles/profiles.module";
+import { AuthModule } from '../auth/auth.module';
+import { ProfilesModule } from '../profiles/profiles.module';
 
 @Module({
   imports: [AuthModule, ProfilesModule],

--- a/BackEnd/src/posts/entities/posts.entity.ts
+++ b/BackEnd/src/posts/entities/posts.entity.ts
@@ -10,9 +10,11 @@ import {
 } from 'typeorm';
 import { Record } from '../../records/entities/records.entity';
 import { Profile } from '../../profiles/entities/profiles.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity()
 export class Post {
+  @ApiProperty({ example: '1', description: '테이블 id를 의미합니다.' })
   @PrimaryGeneratedColumn()
   id: number;
 
@@ -34,6 +36,10 @@ export class Post {
   @Column()
   deletedAt: Date;
 
+  @ApiProperty({
+    example: 'https://www.naver.com',
+    description: '게시물 url을 의미합니다.',
+  })
   @Column()
   postUrl: string;
 

--- a/BackEnd/src/posts/entities/posts.entity.ts
+++ b/BackEnd/src/posts/entities/posts.entity.ts
@@ -34,6 +34,9 @@ export class Post {
   @Column()
   deletedAt: Date;
 
+  @Column()
+  postUrl: string;
+
   @OneToOne(() => Record)
   @JoinColumn()
   record: Record;

--- a/BackEnd/src/profiles/dto/create-profile.dto.ts
+++ b/BackEnd/src/profiles/dto/create-profile.dto.ts
@@ -1,0 +1,21 @@
+import { Profile } from '../entities/profiles.entity';
+import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
+import { SuccessResDto } from '../../common/dto/SuccessRes.dto';
+import { Post } from '../../posts/entities/posts.entity';
+
+export class GetResPostUrl extends PickType(Post, ['id', 'postUrl']) {}
+
+class GetResProfile extends PickType(Profile, [
+  'nickname',
+  'gender',
+  'birthdate',
+  'publicId',
+  'profileImage',
+]) {}
+
+class Intersection extends IntersectionType(GetResProfile, GetResPostUrl) {}
+
+export class GetResProfileDto extends SuccessResDto {
+  @ApiProperty({ type: () => Intersection })
+  data: Intersection;
+}

--- a/BackEnd/src/profiles/dto/create-profile.dto.ts
+++ b/BackEnd/src/profiles/dto/create-profile.dto.ts
@@ -1,6 +1,5 @@
 import { Profile } from '../entities/profiles.entity';
-import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
-import { SuccessResDto } from '../../common/dto/SuccessRes.dto';
+import { PickType } from '@nestjs/swagger';
 import { Post } from '../../posts/entities/posts.entity';
 
 export class GetResPostUrl extends PickType(Post, ['id', 'postUrl']) {}
@@ -13,9 +12,41 @@ class GetResProfile extends PickType(Profile, [
   'profileImage',
 ]) {}
 
-class Intersection extends IntersectionType(GetResProfile, GetResPostUrl) {}
+export const GetProfileAndPosts = () => {
+  return {
+    example: {
+      code: null,
+      errorMessage: null,
+      data: {
+        profile: {
+          nickname: '닉네임',
+          gender: '남자',
+          birthdate: '2021-01-01',
+          publicId: 'adsd2daw-ad2dawd-q1323123',
+          profileImage:
+            'https://s3.ap-northeast-2.amazonaws.com/recordapp/adsd2daw-ad2dawd-q1323123',
+        },
+        posts: [
+          {
+            id: 1,
+            postUrl: 'https://www.naver.com',
+          },
+          {
+            id: 2,
+            postUrl: 'https://www.naver.com',
+          },
+        ],
+      },
+    },
+  };
+};
 
-export class GetResProfileDto extends SuccessResDto {
-  @ApiProperty({ type: () => Intersection })
-  data: Intersection;
-}
+export const SuccessProfile = () => {
+  return {
+    example: {
+      code: null,
+      errorMessage: null,
+      data: null,
+    },
+  };
+};

--- a/BackEnd/src/profiles/dto/update-profile.dto.ts
+++ b/BackEnd/src/profiles/dto/update-profile.dto.ts
@@ -1,0 +1,7 @@
+import { PickType } from '@nestjs/swagger';
+import { Profile } from '../entities/profiles.entity';
+
+export class UpdateProfileDto extends PickType(Profile, [
+  'nickname',
+  'profileImage',
+]) {}

--- a/BackEnd/src/profiles/entities/profiles.entity.ts
+++ b/BackEnd/src/profiles/entities/profiles.entity.ts
@@ -58,8 +58,11 @@ export class Profile {
   @Generated('uuid')
   publicId: string;
 
+  @ApiProperty({
+    example: 'https://s3.bucket.url',
+    description: '프로필 이미지 url을 의미합니다.',
+  })
   @Column({ nullable: true })
-  @IsUrl()
   profileImage: string;
 
   @OneToOne(() => User, (user) => user.profile)

--- a/BackEnd/src/profiles/exception/profile.exception.ts
+++ b/BackEnd/src/profiles/exception/profile.exception.ts
@@ -1,0 +1,12 @@
+import { HttpException } from '@nestjs/common';
+
+export class PublicIdMismatchException extends HttpException {
+  constructor() {
+    const response = {
+      statusCode: 2030,
+      message: 'misMatch',
+    };
+    const httpCode = 400;
+    super(response, httpCode);
+  }
+}

--- a/BackEnd/src/profiles/profiles.controller.ts
+++ b/BackEnd/src/profiles/profiles.controller.ts
@@ -1,7 +1,56 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  UseGuards,
+} from '@nestjs/common';
 import { ProfilesService } from './profiles.service';
+import { GetResProfileDto } from './dto/create-profile.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ProfileDeco } from './decorator/profile.decorator';
+import { Profile } from './entities/profiles.entity';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AccessTokenGuard } from '../auth/guard/bearerToken.guard';
 
+@ApiTags('Profiles API')
 @Controller('profiles')
 export class ProfilesController {
   constructor(private readonly profilesService: ProfilesService) {}
+
+  @ApiOperation({ summary: '프로필을 조회한다.' })
+  @ApiResponse({ type: GetResProfileDto })
+  @UseGuards(AccessTokenGuard)
+  @Get(':publicId')
+  async getMyProfile(@Param('publicId') publicId: string) {
+    return this.profilesService.getProfile(publicId);
+  }
+
+  @ApiOperation({ summary: '프로필을 수정한다. 닉네임 또는 사진' })
+  @ApiBody({ type: UpdateProfileDto })
+  @UseGuards(AccessTokenGuard)
+  @Patch(':profileId')
+  async updateProfile(
+    @Param('profileId') profileId: string,
+    @Body() updateProfileDto: UpdateProfileDto,
+    @ProfileDeco() profile: Profile,
+  ) {
+    return this.profilesService.updateProfile(
+      profileId,
+      profile.publicId,
+      updateProfileDto,
+    );
+  }
+
+  @ApiOperation({ summary: '프로필을 삭제한다.' })
+  @UseGuards(AccessTokenGuard)
+  @Delete(':profileId')
+  async deleteProfile(
+    @Param('profileId') profileId: string,
+    @ProfileDeco() profile: Profile,
+  ) {
+    return this.profilesService.deleteProfile(profileId, profile.publicId);
+  }
 }

--- a/BackEnd/src/profiles/profiles.controller.ts
+++ b/BackEnd/src/profiles/profiles.controller.ts
@@ -25,7 +25,7 @@ export class ProfilesController {
   @UseGuards(AccessTokenGuard)
   @Get(':publicId')
   async getMyProfile(@Param('publicId') publicId: string) {
-    return this.profilesService.getProfile(publicId);
+    return this.profilesService.getProfileAndPost(publicId);
   }
 
   @ApiOperation({ summary: '프로필을 수정한다. 닉네임 또는 사진' })

--- a/BackEnd/src/profiles/profiles.controller.ts
+++ b/BackEnd/src/profiles/profiles.controller.ts
@@ -16,7 +16,7 @@ import { AccessTokenGuard } from '../auth/guard/bearerToken.guard';
 import { GetProfileAndPosts, SuccessProfile } from './dto/create-profile.dto';
 
 @ApiTags('Profiles API')
-@Controller('profiles')
+@Controller('api/v1/profiles')
 @UseGuards(AccessTokenGuard)
 export class ProfilesController {
   constructor(private readonly profilesService: ProfilesService) {}

--- a/BackEnd/src/profiles/profiles.controller.ts
+++ b/BackEnd/src/profiles/profiles.controller.ts
@@ -8,21 +8,25 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { ProfilesService } from './profiles.service';
-import { GetResProfileDto } from './dto/create-profile.dto';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ProfileDeco } from './decorator/profile.decorator';
 import { Profile } from './entities/profiles.entity';
 import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AccessTokenGuard } from '../auth/guard/bearerToken.guard';
+import { GetProfileAndPosts, SuccessProfile } from './dto/create-profile.dto';
 
 @ApiTags('Profiles API')
 @Controller('profiles')
+@UseGuards(AccessTokenGuard)
 export class ProfilesController {
   constructor(private readonly profilesService: ProfilesService) {}
 
   @ApiOperation({ summary: '프로필을 조회한다.' })
-  @ApiResponse({ type: GetResProfileDto })
-  @UseGuards(AccessTokenGuard)
+  @ApiResponse({
+    status: 200,
+    description: '프로필 조회 성공',
+    schema: GetProfileAndPosts(),
+  })
   @Get(':publicId')
   async getMyProfile(@Param('publicId') publicId: string) {
     return this.profilesService.getProfileAndPost(publicId);
@@ -30,7 +34,11 @@ export class ProfilesController {
 
   @ApiOperation({ summary: '프로필을 수정한다. 닉네임 또는 사진' })
   @ApiBody({ type: UpdateProfileDto })
-  @UseGuards(AccessTokenGuard)
+  @ApiResponse({
+    status: 200,
+    description: '프로필 수정 성공',
+    schema: SuccessProfile(),
+  })
   @Patch(':profileId')
   async updateProfile(
     @Param('profileId') profileId: string,
@@ -45,7 +53,11 @@ export class ProfilesController {
   }
 
   @ApiOperation({ summary: '프로필을 삭제한다.' })
-  @UseGuards(AccessTokenGuard)
+  @ApiResponse({
+    status: 200,
+    description: '프로필 삭제 성공',
+    schema: SuccessProfile(),
+  })
   @Delete(':profileId')
   async deleteProfile(
     @Param('profileId') profileId: string,

--- a/BackEnd/src/profiles/profiles.module.ts
+++ b/BackEnd/src/profiles/profiles.module.ts
@@ -3,10 +3,19 @@ import { ProfilesService } from './profiles.service';
 import { ProfilesController } from './profiles.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Profile } from './entities/profiles.entity';
+import { Post } from '../posts/entities/posts.entity';
+import { AuthService } from '../auth/auth.service';
+import { JwtModule } from '@nestjs/jwt';
+import { UsersService } from '../users/users.service';
+import { AuthAppleService } from '../auth/auth-apple.service';
+import { User } from '../users/entities/users.entity';
 @Module({
-  imports: [TypeOrmModule.forFeature([Profile])],
+  imports: [
+    TypeOrmModule.forFeature([Profile, Post, User]),
+    JwtModule.register({}),
+  ],
   exports: [ProfilesService],
   controllers: [ProfilesController],
-  providers: [ProfilesService],
+  providers: [ProfilesService, AuthService, UsersService, AuthAppleService],
 })
 export class ProfilesModule {}

--- a/BackEnd/src/profiles/profiles.module.ts
+++ b/BackEnd/src/profiles/profiles.module.ts
@@ -3,7 +3,6 @@ import { ProfilesService } from './profiles.service';
 import { ProfilesController } from './profiles.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Profile } from './entities/profiles.entity';
-
 @Module({
   imports: [TypeOrmModule.forFeature([Profile])],
   exports: [ProfilesService],

--- a/BackEnd/src/profiles/profiles.service.ts
+++ b/BackEnd/src/profiles/profiles.service.ts
@@ -15,7 +15,7 @@ export class ProfilesService {
     private readonly profilesRepository: Repository<Profile>,
   ) {}
 
-  async getProfile(publicId: string) {
+  async getProfileAndPost(publicId: string) {
     const posts = await this.postsRepository.find({
       where: {
         publicId: publicId,
@@ -63,6 +63,14 @@ export class ProfilesService {
     return this.profilesRepository.exist({
       where: {
         nickname,
+      },
+    });
+  }
+
+  async getProfile(publicId: string) {
+    return this.profilesRepository.findOne({
+      where: {
+        publicId,
       },
     });
   }

--- a/BackEnd/src/profiles/profiles.service.ts
+++ b/BackEnd/src/profiles/profiles.service.ts
@@ -2,33 +2,68 @@ import { Injectable } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { Profile } from './entities/profiles.entity';
 import { InjectRepository } from '@nestjs/typeorm';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { PublicIdMismatchException } from './exception/profile.exception';
+import { Post } from '../posts/entities/posts.entity';
 
 @Injectable()
 export class ProfilesService {
   constructor(
+    @InjectRepository(Post)
+    private readonly postsRepository: Repository<Post>,
     @InjectRepository(Profile)
     private readonly profilesRepository: Repository<Profile>,
   ) {}
 
-  async findByPublicId(publicId: string) {
+  async getProfile(publicId: string) {
+    const posts = await this.postsRepository.find({
+      where: {
+        publicId: publicId,
+      },
+      order: {
+        createdAt: 'DESC',
+      },
+      take: 9,
+      select: ['id', 'postUrl'],
+    });
     const profile = await this.profilesRepository.findOne({
       where: {
         publicId,
       },
+      select: ['nickname', 'gender', 'birthdate', 'publicId', 'profileImage'],
     });
-
-    return profile;
+    return {
+      profile,
+      posts,
+    };
   }
 
-  async existByNickname(nickname: string) {
-    const nicknameExists = await this.profilesRepository.exist({
+  async updateProfile(
+    profileId: string,
+    publicId: string,
+    updateProfileDto: UpdateProfileDto,
+  ) {
+    if (!this.validateProfileId(profileId, publicId)) {
+      throw new PublicIdMismatchException();
+    }
+    return this.profilesRepository.update({ publicId }, updateProfileDto);
+  }
+
+  async deleteProfile(profileId: string, publicId: string) {
+    if (!this.validateProfileId(profileId, publicId)) {
+      throw new PublicIdMismatchException();
+    }
+    return this.profilesRepository.delete({ publicId });
+  }
+
+  private validateProfileId(profileId: string, publicId: string) {
+    return profileId === publicId;
+  }
+  async validateProfileNickname(nickname: string) {
+    return this.profilesRepository.exist({
       where: {
         nickname,
       },
     });
-    if (nicknameExists) {
-      return true;
-    }
-    return false;
   }
 }

--- a/BackEnd/src/users/users.service.ts
+++ b/BackEnd/src/users/users.service.ts
@@ -15,21 +15,22 @@ export class UsersService {
     private readonly redisData: Redis,
   ) {}
 
-  async createUser(singupInfo: SignupDto) {
-    const userId = await this.redisData.get(singupInfo.mappedUserID);
+  async createUser(signupInfo: SignupDto) {
+    const userId = await this.redisData.get(signupInfo.mappedUserID);
     const profile = {
-      nickname: singupInfo.nickname,
-      gender: singupInfo.gender,
-      birthdate: singupInfo.birthdate,
+      nickname: signupInfo.nickname,
+      gender: signupInfo.gender,
+      birthdate: signupInfo.birthdate,
+      profileImage: signupInfo.profileImage,
     };
     const userObj = this.usersRepository.create({
       userId,
-      provider: singupInfo.provider,
+      provider: signupInfo.provider,
       profile,
     });
-    const newUesr = await this.usersRepository.save(userObj);
-    await this.redisData.del(singupInfo.mappedUserID);
-    return newUesr;
+    const newUser = await this.usersRepository.save(userObj);
+    await this.redisData.del(signupInfo.mappedUserID);
+    return newUser;
   }
 
   async getUserByUserIdAndProvider(userInfo: GetuserByUserIdAndProViderDto) {


### PR DESCRIPTION
## Screenshots 📸

|Profile API 구현|
|:-:|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/56383948/40b2dae9-8d8d-457e-80f5-4b4095a446a3)|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/56383948/075480c0-8211-490b-a982-6db750a56d47)|


<br/>

- [x] Profile API를 구현한다.
- [x] Profile API 스웨거를 작성한다.
- [x] Profile API를 노션에 작성한다.

<br/>

## 고민, 과정, 근거 💬

<br/>

- Profile에서 Get을 할 때, 최신 게시물의 9개까지 요청을 보내고, 이미지 URL과 게시물의 id를 리턴하도록 만들었습니다.
- Create 부분은 User 레포지토리에 로직이 존재하기에 삭제했습니다.

<br/>

## References 📋


<br/><br/>

---

- Closed: #176 
