### PR TITLE
[GWL-218] 회원가입(2) UI 구성

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -18,9 +18,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
     let navigationController = UINavigationController()
     window = UIWindow(windowScene: windowScene)
-    let coordinator = AppCoordinator(navigationController: navigationController)
-    coordinating = coordinator
-    coordinator.start()
+    let vc = SignUpProfileViewController()
+    window?.rootViewController = vc
+//    let coordinator = AppCoordinator(navigationController: navigationController)
+//    coordinating = coordinator
+//    coordinator.start()
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -18,10 +18,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
     let navigationController = UINavigationController()
     window = UIWindow(windowScene: windowScene)
-    window?.rootViewController = navigationController
-    let coordinator = AppCoordinator(navigationController: navigationController)
-    coordinating = coordinator
-    coordinator.start()
+    let vc = SignUpProfileViewController()
+    window?.rootViewController = vc
+//    let coordinator = AppCoordinator(navigationController: navigationController)
+//    coordinating = coordinator
+//    coordinator.start()
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -18,11 +18,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
     let navigationController = UINavigationController()
     window = UIWindow(windowScene: windowScene)
-    let vc = SignUpProfileViewController()
-    window?.rootViewController = vc
-//    let coordinator = AppCoordinator(navigationController: navigationController)
-//    coordinating = coordinator
-//    coordinator.start()
+    window?.rootViewController = navigationController
+    let coordinator = AppCoordinator(navigationController: navigationController)
+    coordinating = coordinator
+    coordinator.start()
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/Features/SignUp/Sources/View/DatePickerBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/DatePickerBoxView.swift
@@ -29,6 +29,7 @@ final class DatePickerBoxView: UIView {
     label.translatesAutoresizingMaskIntoConstraints = false
     label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
     label.text = "1998년 06월 15일"
+    label.textColor = DesignSystemColor.primaryText
     return label
   }()
 

--- a/iOS/Projects/Features/SignUp/Sources/View/DatePickerBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/DatePickerBoxView.swift
@@ -68,17 +68,17 @@ private extension DatePickerBoxView {
 
     addSubview(birthLabel)
     NSLayoutConstraint.activate([
-      birthLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-      birthLabel.topAnchor.constraint(equalTo: topAnchor, constant: 13),
-      birthLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -13),
+      birthLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.parentViewInterval),
+      birthLabel.topAnchor.constraint(equalTo: topAnchor, constant: Metrics.topBottomInteval),
+      birthLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metrics.topBottomInteval),
     ])
 
     addSubview(calendarButton)
     NSLayoutConstraint.activate([
-      calendarButton.topAnchor.constraint(equalTo: topAnchor, constant: 13),
-      calendarButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
-      calendarButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -13),
-      calendarButton.widthAnchor.constraint(equalToConstant: 32),
+      calendarButton.topAnchor.constraint(equalTo: topAnchor, constant: Metrics.topBottomInteval),
+      calendarButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.parentViewInterval),
+      calendarButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metrics.topBottomInteval),
+      calendarButton.widthAnchor.constraint(equalToConstant: Metrics.buttonWidth),
     ])
   }
 
@@ -90,4 +90,12 @@ private extension DatePickerBoxView {
       }
       .store(in: &subscriptions)
   }
+}
+
+// MARK: - Metrics
+
+private enum Metrics {
+  static let parentViewInterval: CGFloat = 16
+  static let topBottomInteval: CGFloat = 13
+  static let buttonWidth: CGFloat = 32
 }

--- a/iOS/Projects/Features/SignUp/Sources/View/DatePickerBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/DatePickerBoxView.swift
@@ -61,7 +61,7 @@ extension DatePickerBoxView {
 
 private extension DatePickerBoxView {
   func configureUI() {
-    backgroundColor = .systemBackground
+    backgroundColor = DesignSystemColor.primaryBackground
     layer.borderColor = DesignSystemColor.main03.cgColor
     layer.borderWidth = 1.5
     layer.cornerRadius = 10.0

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -77,13 +77,13 @@ private extension NickNameBoxView {
 
   func enabledNickName() {
     textField.textColor = .black
-    textField.layer.borderColor = DesignSystemColor.main03.cgColor
+    layer.borderColor = DesignSystemColor.main03.cgColor
     cancelButton.tintColor = DesignSystemColor.main03
   }
 
   func disabledNickName() {
+    layer.borderColor = DesignSystemColor.error.cgColor
     textField.textColor = DesignSystemColor.error
-    textField.layer.borderColor = DesignSystemColor.error.cgColor
     cancelButton.tintColor = DesignSystemColor.error
   }
 

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -26,7 +26,7 @@ final class NickNameBoxView: UIView {
     let textField = UITextField()
     textField.translatesAutoresizingMaskIntoConstraints = false
     textField.font = .systemFont(ofSize: 16, weight: .semibold)
-    textField.textColor = .black
+    textField.textColor = DesignSystemColor.primaryText
     textField.placeholder = "닉네임을 입력해주세요!"
     return textField
   }()
@@ -76,7 +76,7 @@ private extension NickNameBoxView {
   }
 
   func enabledNickName() {
-    textField.textColor = .black
+    textField.textColor = DesignSystemColor.primaryText
     layer.borderColor = DesignSystemColor.main03.cgColor
     cancelButton.tintColor = DesignSystemColor.main03
   }

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -61,17 +61,17 @@ private extension NickNameBoxView {
 
     addSubview(textField)
     NSLayoutConstraint.activate([
-      textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
-      textField.topAnchor.constraint(equalTo: topAnchor, constant: 13),
-      textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -13),
+      textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.parentViewInterval),
+      textField.topAnchor.constraint(equalTo: topAnchor, constant: Metrics.topBottomInteval),
+      textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metrics.topBottomInteval),
     ])
 
     addSubview(cancelButton)
     NSLayoutConstraint.activate([
-      cancelButton.topAnchor.constraint(equalTo: topAnchor, constant: 13),
-      cancelButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
-      cancelButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -13),
-      cancelButton.widthAnchor.constraint(equalToConstant: 32),
+      cancelButton.topAnchor.constraint(equalTo: topAnchor, constant: Metrics.topBottomInteval),
+      cancelButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.parentViewInterval),
+      cancelButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metrics.topBottomInteval),
+      cancelButton.widthAnchor.constraint(equalToConstant: Metrics.buttonWidth),
     ])
   }
 
@@ -103,4 +103,12 @@ private extension NickNameBoxView {
       }
       .store(in: &subscriptions)
   }
+}
+
+// MARK: - Metrics
+
+private enum Metrics {
+  static let parentViewInterval: CGFloat = 16
+  static let topBottomInteval: CGFloat = 13
+  static let buttonWidth: CGFloat = 32
 }

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -74,13 +74,13 @@ private extension NickNameBoxView {
       cancelButton.widthAnchor.constraint(equalToConstant: 32),
     ])
   }
-  
+
   func enabledNickName() {
     textField.textColor = .black
     textField.layer.borderColor = DesignSystemColor.main03.cgColor
     cancelButton.tintColor = DesignSystemColor.main03
   }
-  
+
   func disabledNickName() {
     textField.textColor = DesignSystemColor.error
     textField.layer.borderColor = DesignSystemColor.error.cgColor

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -54,7 +54,7 @@ final class NickNameBoxView: UIView {
 
 private extension NickNameBoxView {
   func configureUI() {
-    backgroundColor = .systemBackground
+    backgroundColor = DesignSystemColor.primaryBackground
     layer.borderColor = DesignSystemColor.main03.cgColor
     layer.borderWidth = 1.5
     layer.cornerRadius = 10.0

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -1,0 +1,9 @@
+//
+//  NickNameBoxView.swift
+//  SignUpFeature
+//
+//  Created by 안종표 on 12/4/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -6,4 +6,101 @@
 //  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
 //
 
-import Foundation
+import Combine
+import CombineCocoa
+import DesignSystem
+import UIKit
+
+// MARK: - NickNameBoxView
+
+final class NickNameBoxView: UIView {
+  private var subscriptions: Set<AnyCancellable> = []
+
+  private let nickNameDidChangedSubject = PassthroughSubject<String, Never>()
+
+  var nickNameDidChangedPublisher: AnyPublisher<String, Never> {
+    return nickNameDidChangedSubject.eraseToAnyPublisher()
+  }
+
+  private let textField: UITextField = {
+    let textField = UITextField()
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    textField.font = .systemFont(ofSize: 16, weight: .semibold)
+    textField.textColor = .black
+    textField.placeholder = "닉네임을 입력해주세요!"
+    return textField
+  }()
+
+  private let cancelButton: UIButton = {
+    let button = UIButton()
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.setImage(UIImage(systemName: "xmark"), for: .normal)
+    button.tintColor = DesignSystemColor.main03
+    return button
+  }()
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configureUI()
+    bindUI()
+    disabledNickName()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("NO Xib")
+  }
+}
+
+private extension NickNameBoxView {
+  func configureUI() {
+    backgroundColor = .systemBackground
+    layer.borderColor = DesignSystemColor.main03.cgColor
+    layer.borderWidth = 1.5
+    layer.cornerRadius = 10.0
+
+    addSubview(textField)
+    NSLayoutConstraint.activate([
+      textField.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+      textField.topAnchor.constraint(equalTo: topAnchor, constant: 13),
+      textField.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -13),
+    ])
+
+    addSubview(cancelButton)
+    NSLayoutConstraint.activate([
+      cancelButton.topAnchor.constraint(equalTo: topAnchor, constant: 13),
+      cancelButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+      cancelButton.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -13),
+      cancelButton.widthAnchor.constraint(equalToConstant: 32),
+    ])
+  }
+  
+  func enabledNickName() {
+    textField.textColor = .black
+    textField.layer.borderColor = DesignSystemColor.main03.cgColor
+    cancelButton.tintColor = DesignSystemColor.main03
+  }
+  
+  func disabledNickName() {
+    textField.textColor = DesignSystemColor.error
+    textField.layer.borderColor = DesignSystemColor.error.cgColor
+    cancelButton.tintColor = DesignSystemColor.error
+  }
+
+  func bindUI() {
+    cancelButton.publisher(.touchUpInside)
+      .sink { [weak self] _ in
+        self?.textField.text = ""
+      }
+      .store(in: &subscriptions)
+
+    textField.publisher(.valueChanged)
+      .sink { [weak self] _ in
+        guard let text = self?.textField.text else {
+          return
+        }
+        self?.nickNameDidChangedSubject.send(text)
+      }
+      .store(in: &subscriptions)
+  }
+}

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameBoxView.swift
@@ -22,7 +22,7 @@ final class NickNameBoxView: UIView {
     return nickNameDidChangedSubject.eraseToAnyPublisher()
   }
 
-  private let textField: UITextField = {
+  let textField: UITextField = {
     let textField = UITextField()
     textField.translatesAutoresizingMaskIntoConstraints = false
     textField.font = .systemFont(ofSize: 16, weight: .semibold)

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
@@ -24,7 +24,7 @@ final class NickNameCheckerView: UIView {
   private let label: UILabel = {
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false
-    label.text = "글자수는 2~20자\n특수문자는 사용할 수 없어요."
+    label.text = "글자수는 2~20자, 특수문자는 사용할 수 없어요."
     label.textColor = DesignSystemColor.error
     label.font = .systemFont(ofSize: 12)
     return label
@@ -33,6 +33,7 @@ final class NickNameCheckerView: UIView {
   override init(frame _: CGRect) {
     super.init(frame: .zero)
     configureUI()
+    configureDisabled()
   }
 
   @available(*, unavailable)
@@ -43,17 +44,17 @@ final class NickNameCheckerView: UIView {
 
 extension NickNameCheckerView {
   func configureEnabled() {
-    label.text = "글자수는 2~20자\n특수문자는 사용할 수 없어요."
-    label.textColor = DesignSystemColor.error
-    imageView.image = UIImage(systemName: "exclamationmark.bubble")
-    imageView.tintColor = DesignSystemColor.error
-  }
-
-  func configureDisabled() {
     label.text = "사용가능한 닉네임이에요."
     label.textColor = DesignSystemColor.main03
     imageView.image = UIImage(systemName: "checkmark.bubble")
     imageView.tintColor = DesignSystemColor.main03
+  }
+
+  func configureDisabled() {
+    label.text = "글자수는 2~20자, 특수문자는 사용할 수 없어요."
+    label.textColor = DesignSystemColor.error
+    imageView.image = UIImage(systemName: "exclamationmark.bubble")
+    imageView.tintColor = DesignSystemColor.error
   }
 }
 

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
@@ -60,6 +60,8 @@ extension NickNameCheckerView {
 
 private extension NickNameCheckerView {
   func configureUI() {
+    backgroundColor = DesignSystemColor.primaryBackground
+    
     addSubview(imageView)
     NSLayoutConstraint.activate([
       imageView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
@@ -61,7 +61,7 @@ extension NickNameCheckerView {
 private extension NickNameCheckerView {
   func configureUI() {
     backgroundColor = DesignSystemColor.primaryBackground
-    
+
     addSubview(imageView)
     NSLayoutConstraint.activate([
       imageView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
@@ -1,0 +1,84 @@
+//
+//  NickNameCheckerView.swift
+//  SignUpFeature
+//
+//  Created by 안종표 on 12/4/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import DesignSystem
+import UIKit
+
+// MARK: - NickNameCheckerView
+
+final class NickNameCheckerView: UIView {
+  private let imageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    imageView.image = UIImage(systemName: "exclamationmark.bubble")
+    imageView.contentMode = .scaleAspectFit
+    imageView.tintColor = DesignSystemColor.error
+    return imageView
+  }()
+
+  private let label: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.text = "글자수는 2~20자\n특수문자는 사용할 수 없어요."
+    label.textColor = DesignSystemColor.error
+    label.font = .systemFont(ofSize: 12)
+    return label
+  }()
+
+  override init(frame _: CGRect) {
+    super.init(frame: .zero)
+    configureUI()
+  }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension NickNameCheckerView {
+  func configureEnabled() {
+    label.text = "글자수는 2~20자\n특수문자는 사용할 수 없어요."
+    label.textColor = DesignSystemColor.error
+    imageView.image = UIImage(systemName: "exclamationmark.bubble")
+    imageView.tintColor = DesignSystemColor.error
+  }
+
+  func configureDisabled() {
+    label.text = "사용가능한 닉네임이에요."
+    label.textColor = DesignSystemColor.main03
+    imageView.image = UIImage(systemName: "checkmark.bubble")
+    imageView.tintColor = DesignSystemColor.main03
+  }
+}
+
+private extension NickNameCheckerView {
+  func configureUI() {
+    addSubview(imageView)
+    NSLayoutConstraint.activate([
+      imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      imageView.topAnchor.constraint(equalTo: topAnchor),
+      imageView.widthAnchor.constraint(equalToConstant: Metrics.imageSize),
+      imageView.heightAnchor.constraint(equalToConstant: Metrics.imageSize),
+    ])
+
+    addSubview(label)
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: Metrics.componentInterval),
+      label.topAnchor.constraint(equalTo: topAnchor),
+      label.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
+    ])
+  }
+}
+
+// MARK: - Metrics
+
+private enum Metrics {
+  static let imageSize: CGFloat = 18
+  static let componentInterval: CGFloat = 4
+}

--- a/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/View/NickNameCheckerView.swift
@@ -30,8 +30,8 @@ final class NickNameCheckerView: UIView {
     return label
   }()
 
-  override init(frame _: CGRect) {
-    super.init(frame: .zero)
+  override init(frame: CGRect) {
+    super.init(frame: frame)
     configureUI()
     configureDisabled()
   }

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
@@ -1,0 +1,15 @@
+//
+//  SignUpContainerViewController.swift
+//  SignUpFeature
+//
+//  Created by 안종표 on 12/5/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import UIKit
+
+final class SignUpContainerViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+}

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
@@ -155,7 +155,7 @@ private extension SignUpGenderBirthViewController {
     view.addSubview(nextButton)
     NSLayoutConstraint.activate([
       nextButton.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
-      nextButton.topAnchor.constraint(equalTo: datePicker.bottomAnchor, constant: 5),
+      nextButton.topAnchor.constraint(equalTo: datePicker.bottomAnchor, constant: Metrics.datePickerToNextButton),
       nextButton.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.safeAreaInterval),
       nextButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -Metrics.safeAreaInterval),
     ])
@@ -225,6 +225,7 @@ private enum Metrics {
   static let topInterval: CGFloat = 81
   static let sectionInterval: CGFloat = 48
   static let componentInterval: CGFloat = 9
+  static let datePickerToNextButton: CGFloat = 5
 }
 
 // MARK: - DateFormatter

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
@@ -23,6 +23,7 @@ public final class SignUpGenderBirthViewController: UIViewController {
     label.translatesAutoresizingMaskIntoConstraints = false
     label.font = .preferredFont(forTextStyle: .title2, weight: .semibold)
     label.text = "먼저, 성별과 태어난 날을 알려주세요."
+    label.textColor = DesignSystemColor.primaryText
     return label
   }()
 
@@ -31,6 +32,7 @@ public final class SignUpGenderBirthViewController: UIViewController {
     label.translatesAutoresizingMaskIntoConstraints = false
     label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
     label.text = "성별"
+    label.textColor = DesignSystemColor.primaryText
     return label
   }()
 
@@ -60,6 +62,7 @@ public final class SignUpGenderBirthViewController: UIViewController {
     label.translatesAutoresizingMaskIntoConstraints = false
     label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
     label.text = "생년월일"
+    label.textColor = DesignSystemColor.primaryText
     return label
   }()
 

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
@@ -102,7 +102,7 @@ public final class SignUpGenderBirthViewController: UIViewController {
 
 private extension SignUpGenderBirthViewController {
   func configureUI() {
-    view.backgroundColor = .systemBackground
+    view.backgroundColor = DesignSystemColor.primaryBackground
 
     [maleButton, femaleButton].forEach {
       genderStackView.addArrangedSubview($0)

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -1,0 +1,57 @@
+//
+//  SignUpProfileViewController.swift
+//  SignUpFeature
+//
+//  Created by 안종표 on 12/4/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import CombineCocoa
+import DesignSystem
+import Log
+import UIKit
+
+final class SignUpProfileViewController: UIViewController {
+  private let subscriptions: Set<AnyCancellable> = []
+  
+  private let titleLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.font = .preferredFont(forTextStyle: .title2, weight: .semibold)
+    label.text = "프로필을 만들어 볼까요?"
+    return label
+  }()
+  
+  private let profileImageButton: GWProfileButton = {
+    let button = GWProfileButton()
+    return button
+  }()
+  
+  private let nickNameLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
+    label.text = "닉네임"
+    return label
+  }()
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+  }
+}
+
+private extension SignUpProfileViewController {
+  func bindUI() {
+    
+  }
+}
+// MARK: - Metrics
+
+private enum Metrics {
+  static let safeAreaInterval: CGFloat = 24
+  static let topInterval: CGFloat = 81
+  static let sectionInterval: CGFloat = 48
+  static let componentInterval: CGFloat = 9
+}

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -87,8 +87,8 @@ private extension SignUpProfileViewController {
     NSLayoutConstraint.activate([
       profileImageButton.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Metrics.sectionInterval),
       profileImageButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-      profileImageButton.widthAnchor.constraint(equalToConstant: 100),
-      profileImageButton.heightAnchor.constraint(equalToConstant: 100),
+      profileImageButton.widthAnchor.constraint(equalToConstant: Metrics.profileImageButtonSize),
+      profileImageButton.heightAnchor.constraint(equalToConstant: Metrics.profileImageButtonSize),
     ])
 
     view.addSubview(nickNameLabel)
@@ -108,14 +108,13 @@ private extension SignUpProfileViewController {
     NSLayoutConstraint.activate([
       nickNameCheckerView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
       nickNameCheckerView.topAnchor.constraint(equalTo: nickNameBoxView.bottomAnchor, constant: Metrics.componentInterval),
-      nickNameCheckerView.widthAnchor.constraint(equalToConstant: 175),
-//      nickNameCheckerView.heightAnchor.constraint(equalToConstant: 18),
+      nickNameCheckerView.widthAnchor.constraint(equalToConstant: Metrics.nickNameCheckerWidth),
     ])
 
     view.addSubview(completionButton)
     NSLayoutConstraint.activate([
       completionButton.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
-      completionButton.topAnchor.constraint(equalTo: nickNameBoxView.bottomAnchor, constant: 258),
+      completionButton.topAnchor.constraint(equalTo: nickNameBoxView.bottomAnchor, constant: Metrics.buttonInteval),
       completionButton.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.safeAreaInterval),
       completionButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -Metrics.safeAreaInterval),
     ])
@@ -147,4 +146,7 @@ private enum Metrics {
   static let topInterval: CGFloat = 81
   static let sectionInterval: CGFloat = 48
   static let componentInterval: CGFloat = 9
+  static let buttonInteval: CGFloat = 258
+  static let profileImageButtonSize: CGFloat = 100
+  static let nickNameCheckerWidth: CGFloat = 175
 }

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -124,7 +124,7 @@ private extension SignUpProfileViewController {
 
 private extension SignUpProfileViewController {
   @objc func viewTapped(gestureRecognizer _: UITapGestureRecognizer) {
-    view.endEditing(true)
+    nickNameBoxView.textField.resignFirstResponder()
   }
 }
 

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -72,7 +72,7 @@ public final class SignUpProfileViewController: UIViewController {
 
 private extension SignUpProfileViewController {
   func configureUI() {
-    view.backgroundColor = .systemBackground
+    view.backgroundColor = DesignSystemColor.primaryBackground
     view.addGestureRecognizer(tapGestureRecognizer)
 
     let safeArea = view.safeAreaLayoutGuide

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -22,6 +22,7 @@ public final class SignUpProfileViewController: UIViewController {
     label.translatesAutoresizingMaskIntoConstraints = false
     label.font = .preferredFont(forTextStyle: .title2, weight: .semibold)
     label.text = "프로필을 만들어 볼까요?"
+    label.textColor = DesignSystemColor.primaryText
     return label
   }()
 
@@ -36,6 +37,7 @@ public final class SignUpProfileViewController: UIViewController {
     label.translatesAutoresizingMaskIntoConstraints = false
     label.font = .preferredFont(forTextStyle: .body, weight: .semibold)
     label.text = "닉네임"
+    label.textColor = DesignSystemColor.primaryText
     return label
   }()
 

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -12,9 +12,11 @@ import DesignSystem
 import Log
 import UIKit
 
+// MARK: - SignUpProfileViewController
+
 final class SignUpProfileViewController: UIViewController {
-  private let subscriptions: Set<AnyCancellable> = []
-  
+  private var subscriptions: Set<AnyCancellable> = []
+
   private let titleLabel: UILabel = {
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false
@@ -22,12 +24,12 @@ final class SignUpProfileViewController: UIViewController {
     label.text = "프로필을 만들어 볼까요?"
     return label
   }()
-  
+
   private let profileImageButton: GWProfileButton = {
     let button = GWProfileButton()
     return button
   }()
-  
+
   private let nickNameLabel: UILabel = {
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false
@@ -36,17 +38,26 @@ final class SignUpProfileViewController: UIViewController {
     return label
   }()
 
+  private let nickNameBoxView: NickNameBoxView = {
+    let view = NickNameBoxView(frame: .zero)
+    return view
+  }()
+
   override func viewDidLoad() {
     super.viewDidLoad()
-    
   }
 }
 
 private extension SignUpProfileViewController {
   func bindUI() {
-    
+    nickNameBoxView.nickNameDidChangedPublisher
+      .sink { _ in
+        // TODO: ViewModel로 닉네임 넘겨서 사용가능한닉인지 아닌지 받아와서 사용가능하면 true/false
+      }
+      .store(in: &subscriptions)
   }
 }
+
 // MARK: - Metrics
 
 private enum Metrics {

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -14,7 +14,7 @@ import UIKit
 
 // MARK: - SignUpProfileViewController
 
-final class SignUpProfileViewController: UIViewController {
+public final class SignUpProfileViewController: UIViewController {
   private var subscriptions: Set<AnyCancellable> = []
 
   private let titleLabel: UILabel = {
@@ -27,6 +27,7 @@ final class SignUpProfileViewController: UIViewController {
 
   private let profileImageButton: GWProfileButton = {
     let button = GWProfileButton()
+    button.translatesAutoresizingMaskIntoConstraints = false
     return button
   }()
 
@@ -40,11 +41,88 @@ final class SignUpProfileViewController: UIViewController {
 
   private let nickNameBoxView: NickNameBoxView = {
     let view = NickNameBoxView(frame: .zero)
+    view.translatesAutoresizingMaskIntoConstraints = false
     return view
   }()
 
-  override func viewDidLoad() {
+  private let nickNameCheckerView: NickNameCheckerView = {
+    let view = NickNameCheckerView(frame: .zero)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    return view
+  }()
+
+  private let completionButton: UIButton = {
+    let configuration = UIButton.Configuration.mainEnabled(title: "완료")
+    let button = UIButton(configuration: configuration)
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.titleLabel?.font = .preferredFont(forTextStyle: .headline, weight: .bold)
+    return button
+  }()
+
+  private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
+
+  override public func viewDidLoad() {
     super.viewDidLoad()
+    configureUI()
+    bindUI()
+  }
+}
+
+private extension SignUpProfileViewController {
+  func configureUI() {
+    view.backgroundColor = .systemBackground
+    view.addGestureRecognizer(tapGestureRecognizer)
+
+    let safeArea = view.safeAreaLayoutGuide
+
+    view.addSubview(titleLabel)
+    NSLayoutConstraint.activate([
+      titleLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
+      titleLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: Metrics.topInterval),
+    ])
+
+    view.addSubview(profileImageButton)
+    NSLayoutConstraint.activate([
+      profileImageButton.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Metrics.sectionInterval),
+      profileImageButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      profileImageButton.widthAnchor.constraint(equalToConstant: 100),
+      profileImageButton.heightAnchor.constraint(equalToConstant: 100),
+    ])
+
+    view.addSubview(nickNameLabel)
+    NSLayoutConstraint.activate([
+      nickNameLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
+      nickNameLabel.topAnchor.constraint(equalTo: profileImageButton.bottomAnchor, constant: Metrics.sectionInterval),
+    ])
+
+    view.addSubview(nickNameBoxView)
+    NSLayoutConstraint.activate([
+      nickNameBoxView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
+      nickNameBoxView.topAnchor.constraint(equalTo: nickNameLabel.bottomAnchor, constant: Metrics.componentInterval),
+      nickNameBoxView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.safeAreaInterval),
+    ])
+
+    view.addSubview(nickNameCheckerView)
+    NSLayoutConstraint.activate([
+      nickNameCheckerView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
+      nickNameCheckerView.topAnchor.constraint(equalTo: nickNameBoxView.bottomAnchor, constant: Metrics.componentInterval),
+      nickNameCheckerView.widthAnchor.constraint(equalToConstant: 175),
+//      nickNameCheckerView.heightAnchor.constraint(equalToConstant: 18),
+    ])
+
+    view.addSubview(completionButton)
+    NSLayoutConstraint.activate([
+      completionButton.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
+      completionButton.topAnchor.constraint(equalTo: nickNameBoxView.bottomAnchor, constant: 258),
+      completionButton.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.safeAreaInterval),
+      completionButton.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -Metrics.safeAreaInterval),
+    ])
+  }
+}
+
+private extension SignUpProfileViewController {
+  @objc func viewTapped(gestureRecognizer _: UITapGestureRecognizer) {
+    view.endEditing(true)
   }
 }
 
@@ -53,6 +131,8 @@ private extension SignUpProfileViewController {
     nickNameBoxView.nickNameDidChangedPublisher
       .sink { _ in
         // TODO: ViewModel로 닉네임 넘겨서 사용가능한닉인지 아닌지 받아와서 사용가능하면 true/false
+        // TODO: NickNameBoxView 사용가능, 불가능
+        // TODO: NickNameCheckerView 사용가능, 불가능
       }
       .store(in: &subscriptions)
   }


### PR DESCRIPTION
## Screenshots 📸

|결과 화면|
|:-:|
|<img src = "https://github.com/JongPyoAhn/Python/assets/68585628/89cf40c8-9e55-4547-9baf-f9fc4ff6a845" width="300" height="500">|

<br/><br/>

## 고민, 과정, 근거 💬
- 뷰를 어떻게 나눌지? 틀렸을 때 색상을 어떻게 설정할지? 에 대해 고민하였습니다.
    - 뷰를 나누는 방법은 간단하게 색상이 같이 변경되거나 하나의 아이템(?)과 같은 단위로 사용할 수 있을 경우 뷰로 나누었습니다.
    - 색상은 각 뷰의 역할대로 뷰 내부에서 처리할 수 있는 함수들을 선언하여 비즈니스로직과 합쳤을 때 바로 색상을 변경할 수 있게 하였습니다.

<br/><br/>

## References 📋
❌

<br/><br/>

---

- Closed: #218 
