### PR TITLE
[GWL-231] 회원가입 ContainerViewController 구현

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -15,16 +15,18 @@ import DesignSystem
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
   private var coordinating: AppCoordinating?
-  private var pageControl: GWPageControl = .init(count: 2)
 
   func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
     guard let windowScene = scene as? UIWindowScene else { return }
-    let navigationController = UINavigationController()
     window = UIWindow(windowScene: windowScene)
-    window?.rootViewController = navigationController
-    let coordinator = AppCoordinator(navigationController: navigationController)
-    coordinating = coordinator
-    coordinator.start()
+    let vc = SignUpContainerViewController(
+      signUpGenderBirthViewController: SignUpGenderBirthViewController(),
+      signUpProfileViewController: SignUpProfileViewController()
+    )
+    window?.rootViewController = vc
+//    let coordinator = AppCoordinator(navigationController: navigationController)
+//    coordinating = coordinator
+//    coordinator.start()
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -21,11 +21,10 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     guard let windowScene = scene as? UIWindowScene else { return }
     let navigationController = UINavigationController()
     window = UIWindow(windowScene: windowScene)
-    let vc = SignUpContainerViewController(signUpGenderBirthViewController: SignUpGenderBirthViewController(), signUpProfileViewController: SignUpProfileViewController())
-    window?.rootViewController = vc
-//    let coordinator = AppCoordinator(navigationController: navigationController)
-//    coordinating = coordinator
-//    coordinator.start()
+    window?.rootViewController = navigationController
+    let coordinator = AppCoordinator(navigationController: navigationController)
+    coordinating = coordinator
+    coordinator.start()
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -10,18 +10,22 @@ import RecordFeature
 import SignUpFeature
 import UIKit
 
+import DesignSystem
+
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   var window: UIWindow?
   private var coordinating: AppCoordinating?
+  private var pageControl: GWPageControl = .init(count: 2)
 
   func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
     guard let windowScene = scene as? UIWindowScene else { return }
     let navigationController = UINavigationController()
     window = UIWindow(windowScene: windowScene)
-    window?.rootViewController = navigationController
-    let coordinator = AppCoordinator(navigationController: navigationController)
-    coordinating = coordinator
-    coordinator.start()
+    let vc = SignUpContainerViewController(signUpGenderBirthViewController: SignUpGenderBirthViewController(), signUpProfileViewController: SignUpProfileViewController())
+    window?.rootViewController = vc
+//    let coordinator = AppCoordinator(navigationController: navigationController)
+//    coordinating = coordinator
+//    coordinator.start()
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
@@ -18,6 +18,9 @@ public final class SignUpContainerViewController: UIViewController {
   private let signUpGenderBirthViewController: SignUpGenderBirthViewController
   private let signUpProfileViewController: SignUpProfileViewController
 
+  private lazy var signUpGenderBirthView = signUpGenderBirthViewController.view
+  private lazy var signUpProfileView = signUpProfileViewController.view
+
   private let gwPageControl: GWPageControl = {
     let gwPageControl = GWPageControl(count: 2)
     gwPageControl.translatesAutoresizingMaskIntoConstraints = false
@@ -41,6 +44,19 @@ public final class SignUpContainerViewController: UIViewController {
   override public func viewDidLoad() {
     super.viewDidLoad()
     configureUI()
+    bindUI()
+  }
+}
+
+private extension SignUpContainerViewController {
+  func bindUI() {
+    signUpGenderBirthViewController.nextButtonTapPublisher
+      .sink { [weak self] _ in
+        self?.signUpGenderBirthView?.isHidden = true
+        self?.signUpProfileView?.isHidden = false
+        self?.gwPageControl.next()
+      }
+      .store(in: &subscriptions)
   }
 }
 
@@ -56,7 +72,12 @@ private extension SignUpContainerViewController {
       gwPageControl.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
     ])
 
-    guard let signUpGenderBirthView = signUpGenderBirthViewController.view else { return }
+    guard let signUpGenderBirthView,
+          let signUpProfileView
+    else {
+      return
+    }
+
     signUpGenderBirthView.translatesAutoresizingMaskIntoConstraints = false
     add(child: signUpGenderBirthViewController)
     NSLayoutConstraint.activate([
@@ -66,7 +87,6 @@ private extension SignUpContainerViewController {
       signUpGenderBirthView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
     ])
 
-    guard let signUpProfileView = signUpProfileViewController.view else { return }
     signUpProfileView.translatesAutoresizingMaskIntoConstraints = false
     add(child: signUpProfileViewController)
     NSLayoutConstraint.activate([
@@ -75,6 +95,8 @@ private extension SignUpContainerViewController {
       signUpProfileView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
       signUpProfileView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
     ])
+
+    signUpProfileView.isHidden = true
   }
 
   func add(child viewController: UIViewController) {

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
@@ -66,6 +66,15 @@ private extension SignUpContainerViewController {
       signUpGenderBirthView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
     ])
 
+    guard let signUpProfileView = signUpProfileViewController.view else { return }
+    signUpProfileView.translatesAutoresizingMaskIntoConstraints = false
+    add(child: signUpProfileViewController)
+    NSLayoutConstraint.activate([
+      signUpProfileView.topAnchor.constraint(equalTo: gwPageControl.bottomAnchor),
+      signUpProfileView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+      signUpProfileView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+      signUpProfileView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+    ])
   }
 
   func add(child viewController: UIViewController) {

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpContainerViewController.swift
@@ -6,10 +6,80 @@
 //  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
 //
 
+import Combine
+import DesignSystem
 import UIKit
 
-final class SignUpContainerViewController: UIViewController {
-  override func viewDidLoad() {
-    super.viewDidLoad()
+// MARK: - SignUpContainerViewController
+
+public final class SignUpContainerViewController: UIViewController {
+  private var subscriptions: Set<AnyCancellable> = []
+
+  private let signUpGenderBirthViewController: SignUpGenderBirthViewController
+  private let signUpProfileViewController: SignUpProfileViewController
+
+  private let gwPageControl: GWPageControl = {
+    let gwPageControl = GWPageControl(count: 2)
+    gwPageControl.translatesAutoresizingMaskIntoConstraints = false
+    return gwPageControl
+  }()
+
+  public init(
+    signUpGenderBirthViewController: SignUpGenderBirthViewController,
+    signUpProfileViewController: SignUpProfileViewController
+  ) {
+    self.signUpGenderBirthViewController = signUpGenderBirthViewController
+    self.signUpProfileViewController = signUpProfileViewController
+    super.init(nibName: nil, bundle: nil)
   }
+
+  @available(*, unavailable)
+  required init?(coder _: NSCoder) {
+    fatalError("No Xib")
+  }
+
+  override public func viewDidLoad() {
+    super.viewDidLoad()
+    configureUI()
+  }
+}
+
+private extension SignUpContainerViewController {
+  func configureUI() {
+    view.backgroundColor = DesignSystemColor.secondaryBackground
+    navigationController?.navigationBar.isHidden = true
+    let safeArea = view.safeAreaLayoutGuide
+
+    view.addSubview(gwPageControl)
+    NSLayoutConstraint.activate([
+      gwPageControl.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: Metrics.safeAreaInterval),
+      gwPageControl.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
+    ])
+
+    guard let signUpGenderBirthView = signUpGenderBirthViewController.view else { return }
+    signUpGenderBirthView.translatesAutoresizingMaskIntoConstraints = false
+    add(child: signUpGenderBirthViewController)
+    NSLayoutConstraint.activate([
+      signUpGenderBirthView.topAnchor.constraint(equalTo: gwPageControl.bottomAnchor),
+      signUpGenderBirthView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+      signUpGenderBirthView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+      signUpGenderBirthView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+    ])
+
+  }
+
+  func add(child viewController: UIViewController) {
+    addChild(viewController)
+    view.addSubview(viewController.view)
+    viewController.didMove(toParent: viewController)
+  }
+}
+
+// MARK: - Metrics
+
+private enum Metrics {
+  static let pageControlInterval: CGFloat = 30
+  static let safeAreaInterval: CGFloat = 24
+  static let bottomInterval: CGFloat = 215
+  static let calendarHeight: CGFloat = 51
 }

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
@@ -102,7 +102,7 @@ public final class SignUpGenderBirthViewController: UIViewController {
 
 private extension SignUpGenderBirthViewController {
   func configureUI() {
-    view.backgroundColor = DesignSystemColor.primaryBackground
+    view.backgroundColor = DesignSystemColor.secondaryBackground
 
     [maleButton, femaleButton].forEach {
       genderStackView.addArrangedSubview($0)
@@ -115,7 +115,7 @@ private extension SignUpGenderBirthViewController {
     view.addSubview(titleLabel)
     NSLayoutConstraint.activate([
       titleLabel.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
-      titleLabel.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: Metrics.topInterval),
+      titleLabel.topAnchor.constraint(equalTo: safeArea.topAnchor),
     ])
 
     view.addSubview(genderLabel)

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpGenderBirthViewController.swift
@@ -18,6 +18,12 @@ public final class SignUpGenderBirthViewController: UIViewController {
   private var subscriptions: Set<AnyCancellable> = []
   private let dateFormatter = DateFormatter()
 
+  private let nextButtonTapSubject = PassthroughSubject<Void, Never>()
+
+  var nextButtonTapPublisher: AnyPublisher<Void, Never> {
+    return nextButtonTapSubject.eraseToAnyPublisher()
+  }
+
   private let titleLabel: UILabel = {
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false
@@ -207,7 +213,7 @@ private extension SignUpGenderBirthViewController {
 
     nextButton.publisher(.touchUpInside)
       .sink { [weak self] _ in
-        //
+        self?.nextButtonTapSubject.send()
       }
       .store(in: &subscriptions)
   }

--- a/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/ViewController/SignUpProfileViewController.swift
@@ -72,7 +72,7 @@ public final class SignUpProfileViewController: UIViewController {
 
 private extension SignUpProfileViewController {
   func configureUI() {
-    view.backgroundColor = DesignSystemColor.primaryBackground
+    view.backgroundColor = DesignSystemColor.secondaryBackground
     view.addGestureRecognizer(tapGestureRecognizer)
 
     let safeArea = view.safeAreaLayoutGuide


### PR DESCRIPTION
## Screenshots 📸

|결과 화면|
|:-:|
|<img src = "https://github.com/JongPyoAhn/Python/assets/68585628/024176e7-b9e4-4939-86b6-2ea31eeea5bb" width="300" height="500">|

<br/><br/>

## 고민, 과정, 근거 💬
- PageControl로 이동할 때, 어떻게 이동해야할까?
    - 팀원분들이 구현한 레퍼런스 2개를 볼 수 있었습니다.
    저는 조금 다른 방식으로 구현했는데요.
    내부에 navigationController를 넣을 필요 없이, 단 2개의 화면만 동작하기 때문에 `isHidden`을 활용해서 가볍게 처리해줬습니다.
    ViewController가 분리되어있지 않다면, isHidden을 사용하게 될 경우 상당히 비대한 VC를 만들어 낼 것 입니다.
    하지만, 현재처럼 ViewController가 분리되어있고 1:1로 각자의 ViewModel을 만들어줄 것이라면 VC의 비대는 일어나지 않을것이고 그렇기 때문에 navigationController가 아닌 isHidden을 선택했습니다.


<br/><br/>

## References 📋
❌

<br/><br/>

---

- Closed: #(issue-here)
