### PR TITLE
[GWL-201] Empty State View + 게시물 가져오기 Mock Data 테스트, 페이지네이션

### DIFF
--- a/iOS/Projects/Features/Profile/Project.swift
+++ b/iOS/Projects/Features/Profile/Project.swift
@@ -7,7 +7,7 @@ let project = Project.makeModule(
   targets: .feature(
     .profile,
     testingOptions: [.unitTest],
-    dependencies: [.designSystem, .trinet, .combineExtension, .combineCocoa, .log, .coordinator],
+    dependencies: [.designSystem, .trinet, .combineExtension, .combineCocoa, .log, .coordinator, .commonNetworkingKeyManager],
     testDependencies: [],
     resources: "Resources/**"
   )

--- a/iOS/Projects/Features/Profile/Resources/Persistency/GetPosts.json
+++ b/iOS/Projects/Features/Profile/Resources/Persistency/GetPosts.json
@@ -1,0 +1,17 @@
+{
+  "code": null,
+  "errorMessage": null,
+  "data": {
+    "items": [
+      {
+        "id": 1,
+        "content": "안녕하세요 누구 누구 입니다.",
+        "postUrl": "https://www.naver.com"
+      }
+    ],
+    "metaData": {
+      "after": 5,
+      "count": 10
+    }
+  }
+}

--- a/iOS/Projects/Features/Profile/Resources/Persistency/GetPosts.json
+++ b/iOS/Projects/Features/Profile/Resources/Persistency/GetPosts.json
@@ -4,14 +4,60 @@
   "data": {
     "items": [
       {
-        "id": 1,
+        "id": 16,
+        "publicId": "d5cd7b66-7ee6-4453-a73e-026126861e96",
         "content": "안녕하세요 누구 누구 입니다.",
+        "like": null,
+        "createdAt": "2023-12-04T05:14:39.679Z",
+        "updatedAt": "2023-12-04T05:14:39.679Z",
+        "deletedAt": null,
+        "postUrl": "https://www.naver.com"
+      },
+      {
+        "id": 15,
+        "publicId": "d5cd7b66-7ee6-4453-a73e-026126861e96",
+        "content": "안녕하세요 누구 누구 입니다.",
+        "like": null,
+        "createdAt": "2023-12-04T05:14:37.996Z",
+        "updatedAt": "2023-12-04T05:14:37.996Z",
+        "deletedAt": null,
+        "postUrl": "https://www.naver.com"
+      },
+      {
+        "id": 14,
+        "publicId": "d5cd7b66-7ee6-4453-a73e-026126861e96",
+        "content": "안녕하세요 누구 누구 입니다.",
+        "like": null,
+        "createdAt": "2023-12-04T05:14:35.312Z",
+        "updatedAt": "2023-12-04T05:14:35.312Z",
+        "deletedAt": null,
+        "postUrl": "https://www.naver.com"
+      },
+      {
+        "id": 13,
+        "publicId": "d5cd7b66-7ee6-4453-a73e-026126861e96",
+        "content": "안녕하세요 누구 누구 입니다.",
+        "like": null,
+        "createdAt": "2023-12-04T05:14:33.071Z",
+        "updatedAt": "2023-12-04T05:14:33.071Z",
+        "deletedAt": null,
+        "postUrl": "https://www.naver.com"
+      },
+      {
+        "id": 12,
+        "publicId": "d5cd7b66-7ee6-4453-a73e-026126861e96",
+        "content": "안녕하세요 누구 누구 입니다.",
+        "like": null,
+        "createdAt": "2023-12-04T05:14:30.528Z",
+        "updatedAt": "2023-12-04T05:14:30.528Z",
+        "deletedAt": null,
         "postUrl": "https://www.naver.com"
       }
     ],
     "metaData": {
-      "after": 5,
-      "count": 10
+      "lastItemId": 12,
+      "isLastCursor": false,
+      "count": 5
     }
   }
 }

--- a/iOS/Projects/Features/Profile/Resources/Persistency/GetPosts.json
+++ b/iOS/Projects/Features/Profile/Resources/Persistency/GetPosts.json
@@ -11,7 +11,7 @@
         "createdAt": "2023-12-04T05:14:39.679Z",
         "updatedAt": "2023-12-04T05:14:39.679Z",
         "deletedAt": null,
-        "postUrl": "https://www.naver.com"
+        "postUrl": "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png"
       },
       {
         "id": 15,
@@ -21,7 +21,7 @@
         "createdAt": "2023-12-04T05:14:37.996Z",
         "updatedAt": "2023-12-04T05:14:37.996Z",
         "deletedAt": null,
-        "postUrl": "https://www.naver.com"
+        "postUrl": "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png"
       },
       {
         "id": 14,
@@ -31,7 +31,7 @@
         "createdAt": "2023-12-04T05:14:35.312Z",
         "updatedAt": "2023-12-04T05:14:35.312Z",
         "deletedAt": null,
-        "postUrl": "https://www.naver.com"
+        "postUrl": "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png"
       },
       {
         "id": 13,
@@ -41,7 +41,7 @@
         "createdAt": "2023-12-04T05:14:33.071Z",
         "updatedAt": "2023-12-04T05:14:33.071Z",
         "deletedAt": null,
-        "postUrl": "https://www.naver.com"
+        "postUrl": "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png"
       },
       {
         "id": 12,
@@ -51,7 +51,7 @@
         "createdAt": "2023-12-04T05:14:30.528Z",
         "updatedAt": "2023-12-04T05:14:30.528Z",
         "deletedAt": null,
-        "postUrl": "https://www.naver.com"
+        "postUrl": "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png"
       }
     ],
     "metaData": {

--- a/iOS/Projects/Features/Profile/Resources/Persistency/GetProfile.json
+++ b/iOS/Projects/Features/Profile/Resources/Persistency/GetProfile.json
@@ -2,22 +2,10 @@
   "code": null,
   "errorMessage": null,
   "data": {
-    "profile": {
-      "nickname": "홍승현",
-      "gender": "남자",
-      "birthdate": "2021-01-01",
-      "publicId": "adsd2daw-ad2dawd-q1323123",
-      "profileImage": "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png"
-    },
-    "posts": [
-      {
-        "id": 1,
-        "postUrl": "https://www.naver.com"
-      },
-      {
-        "id": 2,
-        "postUrl": "https://www.naver.com"
-      }
-    ]
+    "nickname": "홍승현",
+    "gender": "남자",
+    "birthdate": "2021-01-01",
+    "publicId": "adsd2daw-ad2dawd-q1323123",
+    "profileImage": "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png"
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsRequestDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsRequestDTO.swift
@@ -1,0 +1,39 @@
+//
+//  PostsRequestDTO.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/4/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - PostsRequestDTO
+
+struct PostsRequestDTO: Encodable {
+  /// id값보다 낮은 아이템을 가져올 때 설정합니다.
+  ///
+  /// `idMoreThan`과 동시에 사용하면 안 됩니다.
+  let idLessThan: Int?
+
+  /// id값보다 높은 아이템을 가져올 때 설정합니다.
+  ///
+  /// `idMoreThan`과 동시에 사용해선 안 됩니다.
+  let idMoreThan: Int?
+
+  /// 정렬 기준입니다.
+  let orderCreatedAt: Order?
+
+  /// 가져올 아이템 수를 의미합니다.
+  let limit: Int?
+}
+
+// MARK: - Order
+
+enum Order: String, Codable {
+  /// 오름차순
+  case ascending = "ASC"
+
+  /// 내림차순
+  case descending = "DESC"
+}

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsRequestDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsRequestDTO.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - PostsRequestDTO
 
-struct PostsRequestDTO: Encodable {
+public struct PostsRequestDTO: Encodable {
   /// id값보다 낮은 아이템을 가져올 때 설정합니다.
   ///
   /// `idMoreThan`과 동시에 사용하면 안 됩니다.

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
@@ -26,7 +26,7 @@ struct PostsResponseDTO: Codable {
 // MARK: - Post
 
 /// 게시글
-public struct Post: Codable {
+public struct Post: Codable, Hashable {
   /// 게시글 Identifier
   let id: Int
 

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
@@ -1,0 +1,58 @@
+//
+//  PostsResponseDTO.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/4/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+struct PostsResponseDTO: Codable {
+
+  /// 게시글 목록
+  let posts: [Post]
+
+  /// 받아온 게시글의 메타데이터
+  let metaData: MetaData
+
+  enum CodingKeys: String, CodingKey {
+    case posts = "items"
+    case metaData
+  }
+}
+
+// MARK: - Item
+
+/// 게시글
+struct Post: Codable {
+  /// 게시글 Identifier
+  let id: Int
+
+  /// 게시글 내용
+  let content: String
+
+  /// 게시글 이미지 URL
+  let postURL: URL
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case content
+    case postURL = "postUrl"
+  }
+}
+
+// MARK: - MetaData
+
+struct MetaData: Codable {
+  /// 다음에 요청으로 보낼 id값
+  let nextID: Int
+
+  /// 받아온 데이터 개수
+  let count: Int
+
+  enum CodingKeys: String, CodingKey {
+    case nextID = "after"
+    case count
+  }
+}

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
@@ -15,7 +15,7 @@ public struct PostsResponseDTO: Codable {
   let posts: [Post]
 
   /// 받아온 게시글의 메타데이터
-  let metaData: MetaData
+  let metaData: PagingMetaData
 
   enum CodingKeys: String, CodingKey {
     case posts = "items"
@@ -43,9 +43,9 @@ public struct Post: Codable, Hashable {
   }
 }
 
-// MARK: - MetaData
+// MARK: - PagingMetaData
 
-struct MetaData: Codable {
+struct PagingMetaData: Codable {
   /// 받아온 데이터 중 제일 마지막의 ID값
   ///
   /// 다음에 요청으로 보낼 id값입니다.

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 
-struct PostsResponseDTO: Codable {
+// MARK: - PostsResponseDTO
 
+struct PostsResponseDTO: Codable {
   /// 게시글 목록
   let posts: [Post]
 
@@ -22,10 +23,10 @@ struct PostsResponseDTO: Codable {
   }
 }
 
-// MARK: - Item
+// MARK: - Post
 
 /// 게시글
-struct Post: Codable {
+public struct Post: Codable {
   /// 게시글 Identifier
   let id: Int
 

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - PostsResponseDTO
 
-struct PostsResponseDTO: Codable {
+public struct PostsResponseDTO: Codable {
   /// 게시글 목록
   let posts: [Post]
 
@@ -46,14 +46,20 @@ public struct Post: Codable, Hashable {
 // MARK: - MetaData
 
 struct MetaData: Codable {
-  /// 다음에 요청으로 보낼 id값
-  let nextID: Int
+  /// 받아온 데이터 중 제일 마지막의 ID값
+  ///
+  /// 다음에 요청으로 보낼 id값입니다.
+  let lastID: Int
 
   /// 받아온 데이터 개수
   let count: Int
 
+  /// 마지막 커서 여부
+  let isLastCursor: Bool
+
   enum CodingKeys: String, CodingKey {
-    case nextID = "after"
+    case lastID = "lastItemId"
+    case isLastCursor
     case count
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/ProfileDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/ProfileDTO.swift
@@ -12,12 +12,6 @@ import Foundation
 
 /// 프로필 정보를 갖습니다.
 public struct ProfileDTO: Decodable {
-  let profile: ProfileInfo
-}
-
-// MARK: - ProfileInfo
-
-public struct ProfileInfo: Decodable, Hashable {
   /// 닉네임
   let nickname: String
 

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
@@ -13,8 +13,9 @@ import Trinet
 
 // MARK: - ProfileRepository
 
-public struct ProfileRepository {
+public final class ProfileRepository {
   private let provider: TNProvider<ProfileEndPoint>
+  private var nextID: Int?
   private let jsonDecoder: JSONDecoder = {
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyy-MM-dd" // JSON의 날짜 형식에 맞춰 설정합니다.
@@ -36,7 +37,7 @@ public struct ProfileRepository {
 
 extension ProfileRepository: ProfileRepositoryRepresentable {
   public func fetchProfiles() -> AnyPublisher<Profile, Error> {
-    return Deferred {
+    return Deferred { [provider] in
       Future<Data, Error> { promise in
         Task {
           do {
@@ -53,6 +54,28 @@ extension ProfileRepository: ProfileRepositoryRepresentable {
     .map(\.profile)
     .tryMap {
       try Profile(profileData: Data(contentsOf: $0.profileImage), nickname: $0.nickname)
+    }
+    .eraseToAnyPublisher()
+  }
+
+  public func fetchPosts(requestModel: PostsRequestDTO) -> AnyPublisher<[Post], Error> {
+    return Deferred { [provider] in
+      Future<Data, Error> { promise in
+        Task {
+          do {
+            let data = try await provider.request(.fetchPosts(requestModel), interceptor: TNKeychainInterceptor.shared)
+            promise(.success(data))
+          } catch {
+            promise(.failure(error))
+          }
+        }
+      }
+    }
+    .decode(type: GWResponse<PostsResponseDTO>.self, decoder: jsonDecoder)
+    .compactMap(\.data)
+    .map { [weak self] in
+      self?.nextID = $0.metaData.nextID
+      return $0.posts
     }
     .eraseToAnyPublisher()
   }

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
@@ -51,7 +51,6 @@ extension ProfileRepository: ProfileRepositoryRepresentable {
     }
     .decode(type: GWResponse<ProfileDTO>.self, decoder: jsonDecoder)
     .compactMap(\.data)
-    .map(\.profile)
     .tryMap {
       try Profile(profileData: Data(contentsOf: $0.profileImage), nickname: $0.nickname)
     }

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
@@ -62,7 +62,7 @@ extension ProfileRepository: ProfileRepositoryRepresentable {
 
 private enum ProfileEndPoint {
   case fetchProfile
-  case fetchPosts
+  case fetchPosts(PostsRequestDTO)
 }
 
 // MARK: TNEndPoint
@@ -82,7 +82,12 @@ extension ProfileEndPoint: TNEndPoint {
   }
 
   var query: Encodable? {
-    nil
+    switch self {
+    case .fetchProfile:
+      return nil
+    case let .fetchPosts(model):
+      return model
+    }
   }
 
   var body: Encodable? {

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
@@ -13,7 +13,7 @@ import Trinet
 
 // MARK: - ProfileRepository
 
-public final class ProfileRepository {
+public struct ProfileRepository {
   private let provider: TNProvider<ProfileEndPoint>
   private let jsonDecoder: JSONDecoder = {
     let dateFormatter = DateFormatter()
@@ -36,7 +36,7 @@ public final class ProfileRepository {
 
 extension ProfileRepository: ProfileRepositoryRepresentable {
   public func fetchProfiles() -> AnyPublisher<Profile, Error> {
-    return Deferred { [provider] in
+    return Deferred {
       Future<Data, Error> { promise in
         Task {
           do {
@@ -57,7 +57,7 @@ extension ProfileRepository: ProfileRepositoryRepresentable {
   }
 
   public func fetchPosts(nextID: Int?) -> AnyPublisher<PostsResponseDTO, Error> {
-    return Deferred { [provider] in
+    return Deferred {
       Future<Data, Error> { promise in
         Task {
           do {

--- a/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileRepositoryRepresentable.swift
@@ -11,4 +11,5 @@ import Foundation
 
 public protocol ProfileRepositoryRepresentable {
   func fetchProfiles() -> AnyPublisher<Profile, Error>
+  func fetchPosts(resetPagination: Bool) -> AnyPublisher<[Post], Error>
 }

--- a/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileRepositoryRepresentable.swift
@@ -11,5 +11,5 @@ import Foundation
 
 public protocol ProfileRepositoryRepresentable {
   func fetchProfiles() -> AnyPublisher<Profile, Error>
-  func fetchPosts(resetPagination: Bool) -> AnyPublisher<[Post], Error>
+  func fetchPosts(nextID: Int?) -> AnyPublisher<PostsResponseDTO, Error>
 }

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileUseCase.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileUseCase.swift
@@ -29,4 +29,8 @@ extension ProfileUseCase: ProfileUseCaseRepresentable {
   public func fetchProfile() -> AnyPublisher<Profile, Error> {
     return repository.fetchProfiles()
   }
+
+  public func fetchPosts(refresh: Bool = false) -> AnyPublisher<[Post], Error> {
+    return repository.fetchPosts(resetPagination: refresh)
+  }
 }

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileUseCase.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileUseCase.swift
@@ -43,7 +43,7 @@ public final class ProfileUseCase {
   }
 
   /// 가져온 메타데이터를 이용해서 UseCase가 관리하는 pagination 프로퍼티를 설정합니다.
-  private func updateFetchStatus(from metaData: MetaData) {
+  private func updateFetchStatus(from metaData: PagingMetaData) {
     nextRequestID = metaData.lastID
     isLast = metaData.isLastCursor
   }

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileUseCase.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileUseCase.swift
@@ -11,9 +11,17 @@ import Foundation
 
 // MARK: - ProfileUseCase
 
-public struct ProfileUseCase {
+public final class ProfileUseCase {
   // MARK: Properties
 
+  /// 다음에 요청할 커서 id
+  private var nextRequestID: Int?
+
+  /// 마지막 데이터를 가져왔는가
+  private var isLast: Bool = false
+
+  /// 요청한 커서 id로 데이터를 가져왔는지 확인하기 위한 캐싱 변수
+  private var isFetchedByCacheID: [Int?: Bool] = [nil: true]
   private let repository: ProfileRepositoryRepresentable
 
   // MARK: Initializations
@@ -30,7 +38,39 @@ extension ProfileUseCase: ProfileUseCaseRepresentable {
     return repository.fetchProfiles()
   }
 
-  public func fetchPosts(refresh: Bool = false) -> AnyPublisher<[Post], Error> {
-    return repository.fetchPosts(resetPagination: refresh)
+  public func fetchPosts(lastItem: ProfileItem?, refresh: Bool) -> AnyPublisher<[Post], Error> {
+    // 이미 마지막 데이터를 요청했던 경우
+    if isLast {
+      return Empty<[Post], Error>().eraseToAnyPublisher()
+    }
+
+    // 다시 새롭게 데이터를 가져오는 경우
+    if refresh {
+      isFetchedByCacheID = [nil: true]
+      nextRequestID = nil
+      return repository.fetchPosts(nextID: nextRequestID)
+        .map { [weak self] in
+          self?.nextRequestID = $0.metaData.lastID
+          return $0.posts
+        }
+        .eraseToAnyPublisher()
+    }
+
+    // 보내준 item의 id값이 동일해야하고, 주어진 커서ID로 이미 로딩된 경우
+    guard
+      nextRequestID == lastItem?.id,
+      isFetchedByCacheID[nextRequestID, default: false] == false
+    else {
+      return Empty<[Post], Error>().eraseToAnyPublisher()
+    }
+
+    isFetchedByCacheID[nextRequestID] = true
+
+    return repository.fetchPosts(nextID: nextRequestID)
+      .map { [weak self] in
+        self?.nextRequestID = $0.metaData.lastID
+        return $0.posts
+      }
+      .eraseToAnyPublisher()
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileUseCaseRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileUseCaseRepresentable.swift
@@ -11,5 +11,5 @@ import Foundation
 
 public protocol ProfileUseCaseRepresentable {
   func fetchProfile() -> AnyPublisher<Profile, Error>
-  func fetchPosts(refresh: Bool) -> AnyPublisher<[Post], Error>
+  func fetchPosts(lastItem: ProfileItem?, refresh: Bool) -> AnyPublisher<[Post], Error>
 }

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileUseCaseRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileUseCaseRepresentable.swift
@@ -11,4 +11,5 @@ import Foundation
 
 public protocol ProfileUseCaseRepresentable {
   func fetchProfile() -> AnyPublisher<Profile, Error>
+  func fetchPosts(refresh: Bool) -> AnyPublisher<[Post], Error>
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/Coordinator/ProfileCoordinator.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/Coordinator/ProfileCoordinator.swift
@@ -29,14 +29,23 @@ public final class ProfileCoordinator {
   }
 
   public func start() {
-    guard let jsonPath = Bundle(for: Self.self).path(forResource: "GetProfile", ofType: "json"),
-          let jsonData = try? Data(contentsOf: .init(filePath: jsonPath))
+    guard
+      let baseURL = Bundle.main.infoDictionary?["BaseURL"] as? String,
+      let jsonProfilePath = Bundle(for: Self.self).path(forResource: "GetProfile", ofType: "json"),
+      let jsonPostsPath = Bundle(for: Self.self).path(forResource: "GetPosts", ofType: "json"),
+      let jsonProfileData = try? Data(contentsOf: .init(filePath: jsonProfilePath)),
+      let jsonPostsData = try? Data(contentsOf: .init(filePath: jsonPostsPath))
     else {
       Log.make().error("Records Mock 데이터를 생성할 수 없습니다.")
       return
     }
 
-    let session: URLSessionProtocol = isMockEnvironment ? MockURLSession(mockData: jsonData) : URLSession.shared
+    let mockData = [
+      "\(baseURL)/api/v1/profiles": jsonProfileData,
+      "\(baseURL)/api/v1/posts": jsonPostsData,
+    ]
+
+    let session: URLSessionProtocol = isMockEnvironment ? MockURLSession(mockDataByURLString: mockData) : URLSession.shared
 
     let repository = ProfileRepository(session: session)
     let useCase = ProfileUseCase(repository: repository)

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/PostsEmptyStateView.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/PostsEmptyStateView.swift
@@ -1,0 +1,85 @@
+//
+//  PostsEmptyStateView.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/4/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import DesignSystem
+import UIKit
+
+final class PostsEmptyStateView: UICollectionReusableView {
+  // MARK: UI Components
+
+  private let emptyImageView: UIImageView = {
+    let imageView = UIImageView(image: .noResultsImage)
+    imageView.contentMode = .scaleAspectFill
+    return imageView
+  }()
+
+  private let descriptionLabel: UILabel = {
+    let label = UILabel()
+    label.text = "아직 게시글을 올리지 못했네요.\n운동하고 글을 올려주세요."
+    label.numberOfLines = 0
+    label.font = .preferredFont(forTextStyle: .headline)
+    label.textColor = DesignSystemColor.primaryText
+    return label
+  }()
+
+  private let profileStackView: UIStackView = {
+    let stackView = UIStackView()
+    stackView.axis = .vertical
+    stackView.alignment = .center
+    stackView.spacing = 33
+    return stackView
+  }()
+
+  // MARK: Initializations
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupLayouts()
+    setupConstraints()
+  }
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    setupLayouts()
+    setupConstraints()
+  }
+
+  // MARK: - Configurations
+
+  private func setupLayouts() {
+    addSubview(profileStackView)
+    for view in [emptyImageView, descriptionLabel] {
+      profileStackView.addArrangedSubview(view)
+    }
+  }
+
+  private func setupConstraints() {
+    emptyImageView.translatesAutoresizingMaskIntoConstraints = false
+    descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+    profileStackView.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate(
+      [
+        profileStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+        profileStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+        emptyImageView.widthAnchor.constraint(equalToConstant: Metrics.emptyStateImageViewWidth),
+        emptyImageView.heightAnchor.constraint(equalToConstant: Metrics.emptyStateImageViewHeight),
+      ]
+    )
+  }
+}
+
+// MARK: ProfileHeaderView.Metrics
+
+private extension PostsEmptyStateView {
+  enum Metrics {
+    static let emptyStateImageViewWidth: CGFloat = 350
+    static let emptyStateImageViewHeight: CGFloat = 285
+  }
+}

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/PostsEmptyStateView.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/PostsEmptyStateView.swift
@@ -9,6 +9,8 @@
 import DesignSystem
 import UIKit
 
+// MARK: - PostsEmptyStateView
+
 final class PostsEmptyStateView: UICollectionReusableView {
   // MARK: UI Components
 
@@ -41,12 +43,14 @@ final class PostsEmptyStateView: UICollectionReusableView {
     super.init(frame: frame)
     setupLayouts()
     setupConstraints()
+    setupStyles()
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     setupLayouts()
     setupConstraints()
+    setupStyles()
   }
 
   // MARK: - Configurations
@@ -67,19 +71,26 @@ final class PostsEmptyStateView: UICollectionReusableView {
       [
         profileStackView.centerXAnchor.constraint(equalTo: centerXAnchor),
         profileStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+        profileStackView.topAnchor.constraint(equalTo: topAnchor, constant: Metrics.profileStackViewTop),
+        profileStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metrics.profileStackViewTop),
 
         emptyImageView.widthAnchor.constraint(equalToConstant: Metrics.emptyStateImageViewWidth),
-        emptyImageView.heightAnchor.constraint(equalToConstant: Metrics.emptyStateImageViewHeight),
+        emptyImageView.heightAnchor.constraint(equalTo: emptyImageView.widthAnchor, multiplier: Metrics.emptyStateImageViewHeightMultiplier),
       ]
     )
   }
+
+  private func setupStyles() {
+    backgroundColor = DesignSystemColor.gray01
+  }
 }
 
-// MARK: ProfileHeaderView.Metrics
+// MARK: PostsEmptyStateView.Metrics
 
 private extension PostsEmptyStateView {
   enum Metrics {
+    static let profileStackViewTop: CGFloat = 90
     static let emptyStateImageViewWidth: CGFloat = 350
-    static let emptyStateImageViewHeight: CGFloat = 285
+    static let emptyStateImageViewHeightMultiplier: CGFloat = 0.81
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/CompositionalLayoutSugarMethods.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/CompositionalLayoutSugarMethods.swift
@@ -1,0 +1,91 @@
+//
+//  CompositionalLayoutSugarMethods.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/5/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import UIKit
+
+extension UICollectionViewLayout {
+  static func createProfileLayout() -> UICollectionViewLayout {
+    return UICollectionViewCompositionalLayout { sectionNumber, _ in
+      switch sectionNumber {
+      case ProfileSection.header.rawValue:
+        return .createProfileHeaderSection()
+      case ProfileSection.main.rawValue:
+        return .createProfileMainSection()
+      case ProfileSection.emptyState.rawValue:
+        return .createProfileEmptyStateSection()
+      default:
+        return nil
+      }
+    }
+  }
+}
+
+extension NSCollectionLayoutSection {
+  /// 프로필 화면에서 상단 헤더의 레이아웃을 갖는 섹션을 설정합니다.
+  static func createProfileHeaderSection() -> NSCollectionLayoutSection {
+    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
+    let section = NSCollectionLayoutSection(group: group)
+
+    let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(300)) // 대략 300으로 설정함
+    let header = NSCollectionLayoutBoundarySupplementaryItem(
+      layoutSize: headerSize,
+      elementKind: UICollectionView.elementKindSectionHeader,
+      alignment: .top
+    )
+    section.boundarySupplementaryItems = [header]
+
+    return section
+  }
+
+  /// 프로필 화면에서 게시글에 들어가는 레이아웃의 섹션을 설정합니다.
+  static func createProfileMainSection() -> NSCollectionLayoutSection {
+    // 각 아이템의 사이즈를 정의합니다.
+    let itemSize = NSCollectionLayoutSize(
+      widthDimension: .fractionalWidth(1 / 3),
+      heightDimension: .fractionalHeight(1)
+    )
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+    item.contentInsets = NSDirectionalEdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1)
+
+    let groupSize = NSCollectionLayoutSize(
+      widthDimension: .fractionalWidth(1),
+      heightDimension: .fractionalWidth(1 / 3)
+    )
+
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
+    // 섹션 정의
+    return NSCollectionLayoutSection(group: group)
+  }
+
+  /// 프로필 화면에서 게시글이 없을 경우 보여지는 Empty View 섹션을 설정합니다.
+  static func createProfileEmptyStateSection() -> NSCollectionLayoutSection {
+    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
+    let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
+    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+
+    let section = NSCollectionLayoutSection(group: group)
+
+    let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(300))
+    let header = NSCollectionLayoutBoundarySupplementaryItem(
+      layoutSize: headerSize,
+      elementKind: UICollectionView.elementKindSectionFooter,
+      alignment: .top
+    )
+    section.boundarySupplementaryItems = [header]
+
+    return section
+  }
+}

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/SectionItem.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/SectionItem.swift
@@ -16,4 +16,4 @@ enum ProfileSection: Int {
   case emptyState
 }
 
-typealias ProfileItem = String
+typealias ProfileItem = Post

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/SectionItem.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/SectionItem.swift
@@ -10,10 +10,10 @@ import Foundation
 
 // MARK: - ProfileSection
 
-enum ProfileSection: Int {
+public enum ProfileSection: Int {
   case header
   case main
   case emptyState
 }
 
-typealias ProfileItem = Post
+public typealias ProfileItem = Post

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/SectionItem.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileLayouts/SectionItem.swift
@@ -1,0 +1,19 @@
+//
+//  SectionItem.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/5/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+// MARK: - ProfileSection
+
+enum ProfileSection: Int {
+  case header
+  case main
+  case emptyState
+}
+
+typealias ProfileItem = String

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfilePostCell.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfilePostCell.swift
@@ -51,8 +51,8 @@ final class ProfilePostCell: UICollectionViewCell {
   func configure(with model: Post) {
     DispatchQueue.global().async {
       guard let data = try? Data(contentsOf: model.postURL) else { return }
-      DispatchQueue.main.async {
-        self.imageView.image = UIImage(data: data)
+      DispatchQueue.main.async { [weak self] in
+        self?.imageView.image = UIImage(data: data)
       }
     }
   }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfilePostCell.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfilePostCell.swift
@@ -15,6 +15,7 @@ final class ProfilePostCell: UICollectionViewCell {
   private let imageView: UIImageView = {
     let imageView = UIImageView(image: .logoImage)
     imageView.contentMode = .scaleAspectFill
+    imageView.clipsToBounds = true
     return imageView
   }()
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfilePostCell.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfilePostCell.swift
@@ -30,6 +30,8 @@ final class ProfilePostCell: UICollectionViewCell {
     setupViews()
   }
 
+  // MARK: - Configurations
+
   private func setupViews() {
     contentView.backgroundColor = DesignSystemColor.secondaryBackground
     contentView.addSubview(imageView)
@@ -43,5 +45,14 @@ final class ProfilePostCell: UICollectionViewCell {
         imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
       ]
     )
+  }
+
+  func configure(with model: Post) {
+    DispatchQueue.global().async {
+      guard let data = try? Data(contentsOf: model.postURL) else { return }
+      DispatchQueue.main.async {
+        self.imageView.image = UIImage(data: data)
+      }
+    }
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
@@ -146,8 +146,11 @@ private extension ProfileViewController {
   private func updatePostsSnapshots(with model: [Post]) {
     guard let dataSource else { return }
     var snapshot = dataSource.snapshot()
-    snapshot.deleteSections([.emptyState])
     snapshot.appendItems(model, toSection: .main)
+    // 아이템이 존재하면 Empty View 삭제
+    if snapshot.itemIdentifiers.isEmpty == false {
+      snapshot.deleteSections([.emptyState])
+    }
     dataSource.apply(snapshot)
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
@@ -22,7 +22,7 @@ public final class ProfileViewController: UICollectionViewController {
 
   public init(viewModel: ProfileViewModelRepresentable) {
     self.viewModel = viewModel
-    super.init(collectionViewLayout: Self.createProfileLayout())
+    super.init(collectionViewLayout: .createProfileLayout())
   }
 
   @available(*, unavailable)
@@ -90,85 +90,6 @@ public final class ProfileViewController: UICollectionViewController {
   }
 }
 
-// MARK: - Compositional Layout Settings
-
-private extension ProfileViewController {
-  private static func createProfileLayout() -> UICollectionViewLayout {
-    return UICollectionViewCompositionalLayout { sectionNumber, _ in
-      switch sectionNumber {
-      case Section.header.rawValue:
-        return createHeaderSection()
-      case Section.main.rawValue:
-        return createMainSection()
-      case Section.emptyState.rawValue:
-        return createEmptyStateSection()
-      default:
-        return nil
-      }
-    }
-  }
-
-  private static func createHeaderSection() -> NSCollectionLayoutSection {
-    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
-    let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
-    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-
-    let section = NSCollectionLayoutSection(group: group)
-
-    let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(300)) // 대략 300으로 설정함
-    let header = NSCollectionLayoutBoundarySupplementaryItem(
-      layoutSize: headerSize,
-      elementKind: UICollectionView.elementKindSectionHeader,
-      alignment: .top
-    )
-    section.boundarySupplementaryItems = [header]
-
-    return section
-  }
-
-  private static func createMainSection() -> NSCollectionLayoutSection {
-    // 각 아이템의 사이즈를 정의합니다.
-    let itemSize = NSCollectionLayoutSize(
-      widthDimension: .fractionalWidth(1 / 3),
-      heightDimension: .fractionalHeight(1)
-    )
-    let item = NSCollectionLayoutItem(layoutSize: itemSize)
-    item.contentInsets = NSDirectionalEdgeInsets(top: 1, leading: 1, bottom: 1, trailing: 1)
-
-    let groupSize = NSCollectionLayoutSize(
-      widthDimension: .fractionalWidth(1),
-      heightDimension: .fractionalWidth(1 / 3)
-    )
-
-    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-
-    // 섹션 정의
-    return NSCollectionLayoutSection(group: group)
-  }
-
-  private static func createEmptyStateSection() -> NSCollectionLayoutSection {
-    let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
-    let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-    let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(1)) // 높이를 1으로 설정, 아무 값도 넣지 않을 예정임
-    let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
-
-    let section = NSCollectionLayoutSection(group: group)
-
-    let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .estimated(300))
-    let header = NSCollectionLayoutBoundarySupplementaryItem(
-      layoutSize: headerSize,
-      elementKind: UICollectionView.elementKindSectionFooter,
-      alignment: .top
-    )
-    section.boundarySupplementaryItems = [header]
-
-    return section
-  }
-}
-
 // MARK: - Diffable DataSources
 
 private extension ProfileViewController {
@@ -219,17 +140,9 @@ private extension ProfileViewController {
 }
 
 private extension ProfileViewController {
-  typealias ProfileDataSource = UICollectionViewDiffableDataSource<Section, Item>
-  typealias ProfileSnapshot = NSDiffableDataSourceSnapshot<Section, Item>
-  typealias ProfileCellRegistration = UICollectionView.CellRegistration<ProfilePostCell, Item>
+  typealias ProfileDataSource = UICollectionViewDiffableDataSource<ProfileSection, ProfileItem>
+  typealias ProfileSnapshot = NSDiffableDataSourceSnapshot<ProfileSection, ProfileItem>
+  typealias ProfileCellRegistration = UICollectionView.CellRegistration<ProfilePostCell, ProfileItem>
   typealias ProfileReusableRegistration = UICollectionView.SupplementaryRegistration<ProfileHeaderView>
   typealias PostEmptyStateRegistration = UICollectionView.SupplementaryRegistration<PostsEmptyStateView>
-
-  enum Section: Int {
-    case header
-    case main
-    case emptyState
-  }
-
-  typealias Item = String
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
@@ -70,6 +70,8 @@ public final class ProfileViewController: UICollectionViewController {
         self?.updateHeaderSnapshots(with: profile)
       case let .alert(error):
         self?.showAlert(with: error)
+      case let .updatePosts(posts):
+        self?.updatePostsSnapshots(with: posts)
       }
     }
     .store(in: &subscriptions)
@@ -94,7 +96,8 @@ public final class ProfileViewController: UICollectionViewController {
 
 private extension ProfileViewController {
   private func setupDataSource() {
-    let registration = ProfileCellRegistration { _, _, _ in
+    let registration = ProfileCellRegistration { cell, _, post in
+      cell.configure(with: post)
     }
 
     let headerRegistration = ProfileReusableRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] headerView, _, _ in
@@ -135,6 +138,14 @@ private extension ProfileViewController {
     headerInfo = model
     var snapshot = dataSource.snapshot()
     snapshot.reloadSections([.header])
+    dataSource.apply(snapshot)
+  }
+
+  private func updatePostsSnapshots(with model: [Post]) {
+    guard let dataSource else { return }
+    var snapshot = dataSource.snapshot()
+    snapshot.deleteSections([.emptyState])
+    snapshot.appendItems(model, toSection: .main)
     dataSource.apply(snapshot)
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
@@ -17,6 +17,9 @@ public final class ProfileViewController: UICollectionViewController {
   private var dataSource: ProfileDataSource?
   private var headerInfo: Profile?
 
+  /// 페이지네이션 로딩 설정
+  private var isLoading: Bool = false
+
   private let viewModel: ProfileViewModelRepresentable
 
   // MARK: Initializations
@@ -152,6 +155,7 @@ private extension ProfileViewController {
       snapshot.deleteSections([.emptyState])
     }
     dataSource.apply(snapshot)
+    isLoading = false
   }
 }
 
@@ -172,7 +176,8 @@ public extension ProfileViewController {
     let height = scrollView.frame.size.height
 
     // 스크롤이 보이는 뷰 정도의 높이 이전까지 도달했을 때 업데이트
-    if offsetY > contentHeight - height {
+    if offsetY > contentHeight - height && isLoading == false {
+      isLoading = true
       paginationEventSubject.send(())
     }
   }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
@@ -10,6 +10,7 @@ public final class ProfileViewController: UICollectionViewController {
 
   private let viewDidLoadSubject: PassthroughSubject<Void, Never> = .init()
   private let didTapSettingButtonSubject: PassthroughSubject<Void, Never> = .init()
+  private let paginationEventSubject: PassthroughSubject<Void, Never> = .init()
 
   private var subscriptions: Set<AnyCancellable> = []
 
@@ -58,7 +59,8 @@ public final class ProfileViewController: UICollectionViewController {
     viewModel.transform(
       input: .init(
         viewDidLoadPublisher: viewDidLoadSubject.eraseToAnyPublisher(),
-        didTapSettingButtonPublisher: didTapSettingButtonSubject.eraseToAnyPublisher()
+        didTapSettingButtonPublisher: didTapSettingButtonSubject.eraseToAnyPublisher(),
+        paginationEventPublisher: paginationEventSubject.eraseToAnyPublisher()
       )
     )
     .receive(on: RunLoop.main)
@@ -156,4 +158,19 @@ private extension ProfileViewController {
   typealias ProfileCellRegistration = UICollectionView.CellRegistration<ProfilePostCell, ProfileItem>
   typealias ProfileReusableRegistration = UICollectionView.SupplementaryRegistration<ProfileHeaderView>
   typealias PostEmptyStateRegistration = UICollectionView.SupplementaryRegistration<PostsEmptyStateView>
+}
+
+// MARK: - Pagination
+
+public extension ProfileViewController {
+  override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    let offsetY = scrollView.contentOffset.y
+    let contentHeight = scrollView.contentSize.height
+    let height = scrollView.frame.size.height
+
+    // 스크롤이 보이는 뷰 정도의 높이 이전까지 도달했을 때 업데이트
+    if offsetY > contentHeight - height {
+      paginationEventSubject.send(())
+    }
+  }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewController.swift
@@ -10,15 +10,12 @@ public final class ProfileViewController: UICollectionViewController {
 
   private let viewDidLoadSubject: PassthroughSubject<Void, Never> = .init()
   private let didTapSettingButtonSubject: PassthroughSubject<Void, Never> = .init()
-  private let paginationEventSubject: PassthroughSubject<Void, Never> = .init()
+  private let paginationEventSubject: PassthroughSubject<ProfileItem, Never> = .init()
 
   private var subscriptions: Set<AnyCancellable> = []
 
   private var dataSource: ProfileDataSource?
   private var headerInfo: Profile?
-
-  /// 페이지네이션 로딩 설정
-  private var isLoading: Bool = false
 
   private let viewModel: ProfileViewModelRepresentable
 
@@ -155,7 +152,6 @@ private extension ProfileViewController {
       snapshot.deleteSections([.emptyState])
     }
     dataSource.apply(snapshot)
-    isLoading = false
   }
 }
 
@@ -171,14 +167,14 @@ private extension ProfileViewController {
 
 public extension ProfileViewController {
   override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    guard let lastItem = dataSource?.snapshot().itemIdentifiers.min(by: { $0.id < $1.id }) else { return }
     let offsetY = scrollView.contentOffset.y
     let contentHeight = scrollView.contentSize.height
     let height = scrollView.frame.size.height
 
     // 스크롤이 보이는 뷰 정도의 높이 이전까지 도달했을 때 업데이트
-    if offsetY > contentHeight - height && isLoading == false {
-      isLoading = true
-      paginationEventSubject.send(())
+    if offsetY > contentHeight - height {
+      paginationEventSubject.send(lastItem)
     }
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewModel.swift
@@ -7,6 +7,7 @@ public struct ProfileViewModelInput {
   let viewDidLoadPublisher: AnyPublisher<Void, Never>
   let didTapSettingButtonPublisher: AnyPublisher<Void, Never>
   let paginationEventPublisher: AnyPublisher<ProfileItem, Never>
+  let refreshPostsPublisher: AnyPublisher<Void, Never>
 }
 
 public typealias ProfileViewModelOutput = AnyPublisher<ProfileViewModelState, Never>
@@ -16,6 +17,7 @@ public typealias ProfileViewModelOutput = AnyPublisher<ProfileViewModelState, Ne
 public enum ProfileViewModelState {
   case idle
   case setupProfile(Profile)
+  case setupPosts([Post])
   case updatePosts([Post])
   case alert(Error)
 }
@@ -63,9 +65,10 @@ extension ProfileViewModel: ProfileViewModelRepresentable {
       .catch { Just(.alert($0)) }
 
     let postInfoPublisher = input.viewDidLoadPublisher
+      .merge(with: input.refreshPostsPublisher)
       .map { _ in (nil, true) }
       .flatMap(useCase.fetchPosts)
-      .map(ProfileViewModelState.updatePosts)
+      .map(ProfileViewModelState.setupPosts)
       .catch { Just(.alert($0)) }
 
     let updatePostsPublisher = input.paginationEventPublisher

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewModel.swift
@@ -63,10 +63,8 @@ extension ProfileViewModel: ProfileViewModelRepresentable {
       .catch { Just(.alert($0)) }
 
     let updatePostsPublisher = input.paginationEventPublisher
-      .flatMap(maxPublishers: .max(1)) { [useCase] _ in
-        Log.make().debug("호출됨")
-        return useCase.fetchPosts(refresh: false)
-      }
+      .map { _ in return false } // 새로고침 안함
+      .flatMap(useCase.fetchPosts)
       .map(ProfileViewModelState.updatePosts)
       .catch { Just(.alert($0)) }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileScene/ProfileViewModel.swift
@@ -14,6 +14,7 @@ public typealias ProfileViewModelOutput = AnyPublisher<ProfileViewModelState, Ne
 public enum ProfileViewModelState {
   case idle
   case setupProfile(Profile)
+  case updatePosts([Post])
   case alert(Error)
 }
 


### PR DESCRIPTION
## Screenshots 📸

|데이터가 존재할 때|데이터가 존재하지 않을 때|
|:-:|:-:|
|![RPReplay_Final1701842494](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/7cfbca93-dac2-420b-ac57-8a6f137b7b07)|![RPReplay_Final1701761159](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/b1bbc15c-a85b-4bf9-ac23-d8e5c8ec57e1)|
<br/><br/>

## 고민, 과정, 근거 💬

### 페이지네이션을 어떻게 하면 좋을까?

ScrollViewDelegate로 현재 위치값을 기반으로 어느정도 밑으로 다다랐을 때 게시글을 요청하도록 구현했습니다(for 사용자 경험).
그러나, ScrollViewDelegate는 조금만 움직여도 빈번하게 호출되므로, 불필요한 Network요청을 제한하고자 특정 조건을 충족할 때만 데이터 요청을 갖도록 로직을 개선했습니다.

1. `ProfileUseCase`를 리팩토링했습니다.
요청으로 들어오는`nextRequestID`를 캐싱하면서 페이지네이션의 상태를 관리하였고, 덕분에 효율적인 데이터 로딩을 마련했습니다.
만약 처음으로 요청이 들어온 ID값이 있다면, 해당 ID값으로 요청이 들어간 이력이 있는지 확인하고, 없다면 Repository에게 데이터를 요청합니다. 만약 가져온 이력이 있다면 Empty를 리턴합니다(즉 무시합니다).


### Empty State View를 Section으로 나누기

Profile 화면에서 Diffable DataSource의 Section은 아래 그림처럼 나뉩니다.
Cell이 하나라도 있다면 EmptyState Section은 제거되고, 그게 아니라면 남아있게 됩니다.

![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/9866b86e-37d7-4e53-b618-1efeb6f94b34)

그래서 실제 뷰의 섹션은 아래처럼 그려집니다.

![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/af502a91-e495-4289-9f29-3da232f3e49f)



## References 📋

- [ScrollViewDelegate Apple Documentation](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate)
- [Combine Framework Apple Documentation](https://developer.apple.com/documentation/combine)

---

- Closed: #201
