### PR TITLE
[GWL-257] common service 에러 처리, 테스트 코드 작성, 리팩토링

### DIFF
--- a/BackEnd/src/common/common.service.spec.ts
+++ b/BackEnd/src/common/common.service.spec.ts
@@ -1,29 +1,46 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { CommonService } from "./common.service"
-import { BaseEntity, QueryBuilder, SelectQueryBuilder } from "typeorm";
+import { QueryFailedError, Repository } from "typeorm";
+import { posts } from "../posts/mocks/mocks";
+import { Post } from "../posts/entities/posts.entity";
+import { mockGetCreateUpdateQueryOptions, mockItems, mockPaginationDto } from "./mocks/mocks";
+import { InternalServerErrorException } from "@nestjs/common";
+import { getRepositoryToken } from "@nestjs/typeorm";
 
 describe('commonService', () => {
     let service: CommonService;
-
+    let postsRepository: Repository<Post>;
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 CommonService,
+                {
+                    provide: getRepositoryToken(Post),
+                    useValue: {
+                        createQueryBuilder: jest.fn()
+                    }
+                }
             ]
         }).compile();
-        
         service = module.get<CommonService>(CommonService);
+        postsRepository = module.get<Repository<Post>>(getRepositoryToken(Post));
     })
 
     describe('paginate', () => {
         const mockQueryBuilder = {
-            setFindOptions: jest.fn().mockReturnThis(),
-            leftJoin: jest.fn().mockReturnThis(),
-            select: jest.fn().mockReturnThis(),
-            getMany: jest.fn().mockResolvedValue([]),
-          } as any
-        it('QueryBuilder가 잘못 설정되어 있다면 InternalServerErrorException 에러 ', async () => {
-            jest.spyOn(service,'makeQueryBuilder').mockReturnValue(mockQueryBuilder)
+            getMany: jest.fn()
+        } as any
+        it('QueryBuilder가 잘못 설정되어 있다면 InternalServerErrorException 에러', async () => {
+            jest.spyOn(service, 'makeQueryBuilder').mockReturnValue(mockQueryBuilder);
+            jest.spyOn(mockQueryBuilder, 'getMany').mockRejectedValue(new QueryFailedError('SELECT *', [], 'Error message'));
+            await expect(service.paginate(mockPaginationDto, postsRepository, mockGetCreateUpdateQueryOptions)).rejects.toThrow(InternalServerErrorException);
+        })
+
+        it('게시글 요청하면 paginate 함수를 실행해서 요청한 게시글들, metaData 반환', async () => {
+            jest.spyOn(service, 'makeQueryBuilder').mockReturnValue(mockQueryBuilder);
+            jest.spyOn(mockQueryBuilder, 'getMany').mockResolvedValue(mockItems);
+            const result = await service.paginate(mockPaginationDto, postsRepository, mockGetCreateUpdateQueryOptions);
+            expect(result).toEqual(posts);
         })
     })
 })

--- a/BackEnd/src/common/common.service.spec.ts
+++ b/BackEnd/src/common/common.service.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { CommonService } from "./common.service"
+
+describe('commonService', () => {
+    let service: CommonService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CommonService,
+            ]
+        }).compile();
+        
+        service = module.get<CommonService>(CommonService);
+    })
+
+    describe('composeFindManyOptions', () => {
+        
+    })
+})

--- a/BackEnd/src/common/common.service.spec.ts
+++ b/BackEnd/src/common/common.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { CommonService } from "./common.service"
+import { BaseEntity, QueryBuilder, SelectQueryBuilder } from "typeorm";
 
 describe('commonService', () => {
     let service: CommonService;
@@ -14,7 +15,15 @@ describe('commonService', () => {
         service = module.get<CommonService>(CommonService);
     })
 
-    describe('composeFindManyOptions', () => {
-        
+    describe('paginate', () => {
+        const mockQueryBuilder = {
+            setFindOptions: jest.fn().mockReturnThis(),
+            leftJoin: jest.fn().mockReturnThis(),
+            select: jest.fn().mockReturnThis(),
+            getMany: jest.fn().mockResolvedValue([]),
+          } as any
+        it('QueryBuilder가 잘못 설정되어 있다면 InternalServerErrorException 에러 ', async () => {
+            jest.spyOn(service,'makeQueryBuilder').mockReturnValue(mockQueryBuilder)
+        })
     })
 })

--- a/BackEnd/src/common/common.service.spec.ts
+++ b/BackEnd/src/common/common.service.spec.ts
@@ -1,46 +1,64 @@
-import { Test, TestingModule } from "@nestjs/testing";
-import { CommonService } from "./common.service"
-import { QueryFailedError, Repository } from "typeorm";
-import { posts } from "../posts/mocks/mocks";
-import { Post } from "../posts/entities/posts.entity";
-import { mockGetCreateUpdateQueryOptions, mockItems, mockPaginationDto } from "./mocks/mocks";
-import { InternalServerErrorException } from "@nestjs/common";
-import { getRepositoryToken } from "@nestjs/typeorm";
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommonService } from './common.service';
+import { QueryFailedError, Repository } from 'typeorm';
+import { posts } from '../posts/mocks/mocks';
+import { Post } from '../posts/entities/posts.entity';
+import {
+  mockGetCreateUpdateQueryOptions,
+  mockItems,
+  mockPaginationDto,
+} from './mocks/mocks';
+import { InternalServerErrorException } from '@nestjs/common';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 describe('commonService', () => {
-    let service: CommonService;
-    let postsRepository: Repository<Post>;
-    beforeEach(async () => {
-        const module: TestingModule = await Test.createTestingModule({
-            providers: [
-                CommonService,
-                {
-                    provide: getRepositoryToken(Post),
-                    useValue: {
-                        createQueryBuilder: jest.fn()
-                    }
-                }
-            ]
-        }).compile();
-        service = module.get<CommonService>(CommonService);
-        postsRepository = module.get<Repository<Post>>(getRepositoryToken(Post));
-    })
+  let service: CommonService;
+  let postsRepository: Repository<Post>;
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CommonService,
+        {
+          provide: getRepositoryToken(Post),
+          useValue: {
+            createQueryBuilder: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+    service = module.get<CommonService>(CommonService);
+    postsRepository = module.get<Repository<Post>>(getRepositoryToken(Post));
+  });
 
-    describe('paginate', () => {
-        const mockQueryBuilder = {
-            getMany: jest.fn()
-        } as any
-        it('QueryBuilder가 잘못 설정되어 있다면 InternalServerErrorException 에러', async () => {
-            jest.spyOn(service, 'makeQueryBuilder').mockReturnValue(mockQueryBuilder);
-            jest.spyOn(mockQueryBuilder, 'getMany').mockRejectedValue(new QueryFailedError('SELECT *', [], 'Error message'));
-            await expect(service.paginate(mockPaginationDto, postsRepository, mockGetCreateUpdateQueryOptions)).rejects.toThrow(InternalServerErrorException);
-        })
+  describe('paginate', () => {
+    const mockQueryBuilder = {
+      getMany: jest.fn(),
+    } as any;
+    it('QueryBuilder가 잘못 설정되어 있다면 InternalServerErrorException 에러', async () => {
+      jest.spyOn(service, 'makeQueryBuilder').mockReturnValue(mockQueryBuilder);
+      jest
+        .spyOn(mockQueryBuilder, 'getMany')
+        .mockRejectedValue(
+          new QueryFailedError('SELECT *', [], 'Error message'),
+        );
+      await expect(
+        service.paginate(
+          mockPaginationDto,
+          postsRepository,
+          mockGetCreateUpdateQueryOptions,
+        ),
+      ).rejects.toThrow(InternalServerErrorException);
+    });
 
-        it('게시글 요청하면 paginate 함수를 실행해서 요청한 게시글들, metaData 반환', async () => {
-            jest.spyOn(service, 'makeQueryBuilder').mockReturnValue(mockQueryBuilder);
-            jest.spyOn(mockQueryBuilder, 'getMany').mockResolvedValue(mockItems);
-            const result = await service.paginate(mockPaginationDto, postsRepository, mockGetCreateUpdateQueryOptions);
-            expect(result).toEqual(posts);
-        })
-    })
-})
+    it('게시글 요청하면 paginate 함수를 실행해서 요청한 게시글들, metaData 반환', async () => {
+      jest.spyOn(service, 'makeQueryBuilder').mockReturnValue(mockQueryBuilder);
+      jest.spyOn(mockQueryBuilder, 'getMany').mockResolvedValue(mockItems);
+      const result = await service.paginate(
+        mockPaginationDto,
+        postsRepository,
+        mockGetCreateUpdateQueryOptions,
+      );
+      expect(result).toEqual(posts);
+    });
+  });
+});

--- a/BackEnd/src/common/common.service.ts
+++ b/BackEnd/src/common/common.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
-import { EntityMetadata, FindManyOptions, QueryBuilder, Repository } from 'typeorm';
+import { FindManyOptions, Repository } from 'typeorm';
 import { BasePaginationDto } from './dto/base-pagination.dto';
 import { ORM_OPERATION } from './const/orm-operation.const';
 import { BaseModel } from './type/base-model.type';
 import { JoinType, QueryOptions } from './type/query-options.type';
+import { PaginateResponseDto } from './dto/base-paginate-res.dto';
 
 @Injectable()
 export class CommonService {
@@ -12,7 +13,7 @@ export class CommonService {
     repository: Repository<T>,
     queryOptions: QueryOptions,
     overrideFindOptions: FindManyOptions<T> = {},
-  ) {
+  ): Promise<PaginateResponseDto> {
     const findManyOptions: FindManyOptions<T> = {
       ...overrideFindOptions,
     };

--- a/BackEnd/src/common/common.service.ts
+++ b/BackEnd/src/common/common.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
-import { FindManyOptions, Repository } from 'typeorm';
+import { BaseEntity, FindManyOptions, QueryBuilder, Repository, SelectQueryBuilder } from 'typeorm';
 import { BasePaginationDto } from './dto/base-pagination.dto';
 import { ORM_OPERATION } from './const/orm-operation.const';
 import { BaseModel } from './type/base-model.type';
@@ -71,7 +71,7 @@ export class CommonService {
     repository: Repository<T>,
     queryOptions: QueryOptions,
     findManyOptions: FindManyOptions<T> = {},
-  ) {
+  ): SelectQueryBuilder<T> {
     let queryBuilder = repository.createQueryBuilder(queryOptions.mainAlias);
     queryBuilder = queryBuilder.setFindOptions(findManyOptions);
     if (queryOptions.joins) {

--- a/BackEnd/src/common/common.service.ts
+++ b/BackEnd/src/common/common.service.ts
@@ -1,5 +1,15 @@
-import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
-import { BaseEntity, FindManyOptions, QueryBuilder, Repository, SelectQueryBuilder } from 'typeorm';
+import {
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
+import {
+  BaseEntity,
+  FindManyOptions,
+  QueryBuilder,
+  Repository,
+  SelectQueryBuilder,
+} from 'typeorm';
 import { BasePaginationDto } from './dto/base-pagination.dto';
 import { ORM_OPERATION } from './const/orm-operation.const';
 import { BaseModel } from './type/base-model.type';
@@ -38,7 +48,7 @@ export class CommonService {
         },
       };
     } catch (error) {
-      Logger.error(`쿼리 실행 중 오류: ${error.message}`, {error});
+      Logger.error(`쿼리 실행 중 오류: ${error.message}`, { error });
       throw new InternalServerErrorException();
     }
   }

--- a/BackEnd/src/common/dto/base-paginate-res.dto.ts
+++ b/BackEnd/src/common/dto/base-paginate-res.dto.ts
@@ -1,8 +1,8 @@
 export class PaginateResponseDto {
-    items: any[];
-    metaData: {
-      lastItemId: number | null;
-      isLastCursor: boolean;
-      count: number;
-    };
-  }
+  items: any[];
+  metaData: {
+    lastItemId: number | null;
+    isLastCursor: boolean;
+    count: number;
+  };
+}

--- a/BackEnd/src/common/dto/base-paginate-res.dto.ts
+++ b/BackEnd/src/common/dto/base-paginate-res.dto.ts
@@ -1,0 +1,8 @@
+export class PaginateResponseDto {
+    items: any[];
+    metaData: {
+      lastItemId: number | null;
+      isLastCursor: boolean;
+      count: number;
+    };
+  }

--- a/BackEnd/src/common/mocks/mocks.ts
+++ b/BackEnd/src/common/mocks/mocks.ts
@@ -1,0 +1,7 @@
+import { BasePaginationDto } from "../dto/base-pagination.dto";
+
+export const mockPaginationDto: BasePaginationDto = {
+    order__createdAt: 'DESC',
+    take: 5,
+    where__id__less_then: 12
+}

--- a/BackEnd/src/common/mocks/mocks.ts
+++ b/BackEnd/src/common/mocks/mocks.ts
@@ -1,63 +1,63 @@
-import { BasePaginationDto } from "../dto/base-pagination.dto";
+import { BasePaginationDto } from '../dto/base-pagination.dto';
 import { QueryOptions } from '../../common/type/query-options.type';
-import { Profile } from "../../profiles/entities/profiles.entity";
+import { Profile } from '../../profiles/entities/profiles.entity';
 
 export const mockPaginationDto: BasePaginationDto = {
-    order__createdAt: 'DESC',
-    take: 5,
-    where__id__less_then: 7,
-}
+  order__createdAt: 'DESC',
+  take: 5,
+  where__id__less_then: 7,
+};
 export const profile = {
-    publicId: 'XVZXC-ASFSA123-ASFSF',
-    nickname: 'testNickname',
-  } as Profile;
-  
+  publicId: 'XVZXC-ASFSA123-ASFSF',
+  nickname: 'testNickname',
+} as Profile;
+
 export const mockItems = [
-    {
-      id: 6,
-      publicId: profile.publicId,
-      content: '안녕하세요 누구 누구 입니다.',
-      like: null,
-      createdAt: new Date('2023-12-04T05:14:15.879Z'),
-      updatedAt: new Date('2023-12-04T05:14:15.879Z'),
-      deletedAt: null,
-      postUrl: 'https://www.naver.com',
-      record: {
-        id: 2,
-        workoutTime: 6000000,
-        distance: 100000,
-        calorie: 360,
-        avgHeartRate: 60,
-        minHeartRate: 120,
-        maxHeartRate: 180,
-      },
-      profile: {
-        nickname: profile.nickname,
-      },
+  {
+    id: 6,
+    publicId: profile.publicId,
+    content: '안녕하세요 누구 누구 입니다.',
+    like: null,
+    createdAt: new Date('2023-12-04T05:14:15.879Z'),
+    updatedAt: new Date('2023-12-04T05:14:15.879Z'),
+    deletedAt: null,
+    postUrl: 'https://www.naver.com',
+    record: {
+      id: 2,
+      workoutTime: 6000000,
+      distance: 100000,
+      calorie: 360,
+      avgHeartRate: 60,
+      minHeartRate: 120,
+      maxHeartRate: 180,
     },
-    {
-      id: 5,
-      publicId: profile.publicId,
-      content: '수정한 내용입니다.',
-      like: null,
-      createdAt: new Date('2023-12-03T13:47:08.677Z'),
-      updatedAt: new Date('2023-12-04T12:44:44.000Z'),
-      deletedAt: null,
-      postUrl: 'google.com',
-      record: {
-        id: 1,
-        workoutTime: 100,
-        distance: 100,
-        calorie: 100,
-        avgHeartRate: 100,
-        minHeartRate: 100,
-        maxHeartRate: 100,
-      },
-      profile: {
-        nickname: profile.nickname,
-      },
+    profile: {
+      nickname: profile.nickname,
     },
-  ]
+  },
+  {
+    id: 5,
+    publicId: profile.publicId,
+    content: '수정한 내용입니다.',
+    like: null,
+    createdAt: new Date('2023-12-03T13:47:08.677Z'),
+    updatedAt: new Date('2023-12-04T12:44:44.000Z'),
+    deletedAt: null,
+    postUrl: 'google.com',
+    record: {
+      id: 1,
+      workoutTime: 100,
+      distance: 100,
+      calorie: 100,
+      avgHeartRate: 100,
+      minHeartRate: 100,
+      maxHeartRate: 100,
+    },
+    profile: {
+      nickname: profile.nickname,
+    },
+  },
+];
 
 export const mockGetCreateUpdateQueryOptions: QueryOptions = {
   mainAlias: 'post',

--- a/BackEnd/src/common/mocks/mocks.ts
+++ b/BackEnd/src/common/mocks/mocks.ts
@@ -1,7 +1,85 @@
 import { BasePaginationDto } from "../dto/base-pagination.dto";
+import { QueryOptions } from '../../common/type/query-options.type';
+import { Profile } from "../../profiles/entities/profiles.entity";
 
 export const mockPaginationDto: BasePaginationDto = {
     order__createdAt: 'DESC',
     take: 5,
-    where__id__less_then: 12
+    where__id__less_then: 7,
 }
+export const profile = {
+    publicId: 'XVZXC-ASFSA123-ASFSF',
+    nickname: 'testNickname',
+  } as Profile;
+  
+export const mockItems = [
+    {
+      id: 6,
+      publicId: profile.publicId,
+      content: '안녕하세요 누구 누구 입니다.',
+      like: null,
+      createdAt: new Date('2023-12-04T05:14:15.879Z'),
+      updatedAt: new Date('2023-12-04T05:14:15.879Z'),
+      deletedAt: null,
+      postUrl: 'https://www.naver.com',
+      record: {
+        id: 2,
+        workoutTime: 6000000,
+        distance: 100000,
+        calorie: 360,
+        avgHeartRate: 60,
+        minHeartRate: 120,
+        maxHeartRate: 180,
+      },
+      profile: {
+        nickname: profile.nickname,
+      },
+    },
+    {
+      id: 5,
+      publicId: profile.publicId,
+      content: '수정한 내용입니다.',
+      like: null,
+      createdAt: new Date('2023-12-03T13:47:08.677Z'),
+      updatedAt: new Date('2023-12-04T12:44:44.000Z'),
+      deletedAt: null,
+      postUrl: 'google.com',
+      record: {
+        id: 1,
+        workoutTime: 100,
+        distance: 100,
+        calorie: 100,
+        avgHeartRate: 100,
+        minHeartRate: 100,
+        maxHeartRate: 100,
+      },
+      profile: {
+        nickname: profile.nickname,
+      },
+    },
+  ]
+
+export const mockGetCreateUpdateQueryOptions: QueryOptions = {
+  mainAlias: 'post',
+  joins: [
+    {
+      joinColumn: 'post.record',
+      joinAlias: 'record',
+    },
+    {
+      joinColumn: 'post.profile',
+      joinAlias: 'profile',
+    },
+  ],
+  selects: [
+    'post',
+    'record.id',
+    'record.workoutTime',
+    'record.distance',
+    'record.calorie',
+    'record.avgHeartRate',
+    'record.minHeartRate',
+    'record.maxHeartRate',
+    'profile.nickname',
+  ],
+};

--- a/BackEnd/src/common/type/query-options.type.ts
+++ b/BackEnd/src/common/type/query-options.type.ts
@@ -5,6 +5,6 @@ export interface JoinType {
 
 export interface QueryOptions {
   mainAlias: string;
-  join?: JoinType[];
-  select?: string[];
+  joins?: JoinType[];
+  selects?: string[];
 }

--- a/BackEnd/src/images/images.controller.ts
+++ b/BackEnd/src/images/images.controller.ts
@@ -15,7 +15,7 @@ import { ImagesService } from './images.service';
 import { MAX_IMAGE_SIZE } from './constant/images.constant';
 import { ValidateFilesPipe } from './pipe/validate-files.pip';
 import { ImageRequestDto, ImageResponseDto } from './dto/images.response';
-import { FilesInterceptor } from "@nestjs/platform-express";
+import { FilesInterceptor } from '@nestjs/platform-express';
 
 @ApiTags('이미지 업로드 API')
 @Controller('api/v1/images')

--- a/BackEnd/src/images/intercepters/wetri-files.interceptor.ts
+++ b/BackEnd/src/images/intercepters/wetri-files.interceptor.ts
@@ -1,4 +1,9 @@
-import { Injectable, ExecutionContext, CallHandler, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';

--- a/BackEnd/src/posts/queryOptions/get-create-update.queryOptions.ts
+++ b/BackEnd/src/posts/queryOptions/get-create-update.queryOptions.ts
@@ -2,7 +2,7 @@ import { QueryOptions } from '../../common/type/query-options.type';
 
 export const getCreateUpdateQueryOptions: QueryOptions = {
   mainAlias: 'post',
-  join: [
+  joins: [
     {
       joinColumn: 'post.record',
       joinAlias: 'record',
@@ -12,7 +12,7 @@ export const getCreateUpdateQueryOptions: QueryOptions = {
       joinAlias: 'profile',
     },
   ],
-  select: [
+  selects: [
     'post',
     'record.id',
     'record.workoutTime',


### PR DESCRIPTION
## 고민, 과정, 근거 💬
paginate 함수에서 발생할 수 있는 오류는 잘못 설정된 QueryBuilder에서 발생합니다.
여기서 join, select를 잘못 설정하면 sql 오류가 발생합니다.
이 오류는 서버와 관련된 오류이기 때문에 상세한 오류를 프론트로 보내줄 필요는 없고, internal server error를 발생하게 했습니다. (catch문에서)
대신 서버에서는 이 에러를 자세하게 알아야하기 때문에 try catch로 잡아서 Logger.error()로 error message 보여주도록 했습니다.

<br/><br/>

---

- Closed: #257 
