### PR TITLE
[Fix] 소켓 연결시 token에러 핸들링이 안되는 문제, record에 gps 컬럼이 255자였던 건 관하여

### DIFF
--- a/BackEnd/src/auth/auth.service.ts
+++ b/BackEnd/src/auth/auth.service.ts
@@ -130,7 +130,8 @@ export class AuthService {
     const user = await this.checkSignUp(userId);
     if (!user) {
       const mappedUserID = uuidv4();
-      await this.redisData.set(mappedUserID, userId, 'EX', 600);
+      await this.redisData.set(mappedUserID, userId);
+      await this.redisData.expire(mappedUserID, 600);
       return {
         isFirstLogined: true,
         mappedUserID,

--- a/BackEnd/src/live-workouts/events/events.gateway.ts
+++ b/BackEnd/src/live-workouts/events/events.gateway.ts
@@ -12,6 +12,7 @@ import { WetriWebSocket, WetriServer } from './types/custom-websocket.type';
 import { AuthService } from '../../auth/auth.service';
 import { CheckMatchingDto } from './dto/checkMatching.dto';
 import {Logger} from "@nestjs/common";
+import {NotAccessTokenException} from "../../auth/exceptions/auth.exception";
 
 @WebSocketGateway(3003)
 export class EventsGateway
@@ -31,10 +32,13 @@ export class EventsGateway
   async handleConnection(client: WetriWebSocket, ...args: any[]) {
     Logger.log("연결 성공");
     const { authorization, roomid } = args[0].headers;
-    if (!(await this.authService.verifyWs(authorization, client))) {
+    try {
+      await this.authService.verifyWs(authorization, client);
+    } catch (e) {
       client.close();
       return;
     }
+
     const matchInfo: CheckMatchingDto = {
       matchingKey: `userMatch:${client.id}`,
       roomId: roomid,

--- a/BackEnd/src/live-workouts/matches/matches.service.ts
+++ b/BackEnd/src/live-workouts/matches/matches.service.ts
@@ -118,11 +118,12 @@ export class MatchesService {
 
     multi.set(
       `matchProfiles:${roomId}`,
-      JSON.stringify(profiles), 'EX', MATCHES_API_TIME_OUT);
+      JSON.stringify(profiles));
     multi.set(
       `matchStartTime:${roomId}`,
       liveWorkoutStartTimeUTC,
     );
+    multi.expire(`matchProfiles:${roomId}`, MATCHES_API_TIME_OUT);
     multi.expire(`matchStartTime:${roomId}`, UTC_REMOVE_TIME);
     multi.ltrim(`matching:${workoutId}`, waitingUsers, -1);
     await multi.exec();

--- a/BackEnd/src/records/entities/records.entity.ts
+++ b/BackEnd/src/records/entities/records.entity.ts
@@ -90,7 +90,7 @@ export class Record {
     description: '운동 기록 생성 날짜',
   })
   @IsString()
-  @Column()
+  @Column('longtext')
   gps: string;
 
   @Column({ default: false })


### PR DESCRIPTION
## 고민, 과정, 근거 💬

<br/>

- 토큰 에러 헨들링이 안되는 문제를 try catch로 잡고, client.close 해줬습니다. -> 따로 에러 메세지를 전송하려면 미들웨어를 두어야하는데, 이 경우 프로젝트가 끝난 이후에 하려고 합니다.
- gps 컬림을 longtext로 두어 최대 4기가 바이트까지 저장이 가능합니다.
- redis에서 값을 expired할 때, EX 600이 아닌 .expired메서드를 이용했습니다.

<br/>

## References 📋


<br/><br/>

---

- Closed: #290 
- Closed: #279 
