### PR TITLE
[GWL-295] 배포서버와 개발서버 분리

### DIFF
--- a/iOS/Makefile
+++ b/iOS/Makefile
@@ -1,6 +1,10 @@
 generate:
 	tuist fetch
-	TUIST_ROOT_DIR=${PWD} tuist generate
+	TUIST_ROOT_DIR=${PWD} TUIST_SCHEME=DEBUG tuist generate
+
+release:
+	tuist fetch
+	TUIST_ROOT_DIR=${PWD} TUIST_SCHEME=RELEASE tuist generate
 
 feature:
 	chmod +x Scripts/create_module.sh

--- a/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -14,11 +14,10 @@ public extension Project {
     let settings: Settings = .settings(
       base: ["ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS": "YES"],
       configurations: [
-        .debug(name: .debug, xcconfig: isCI ? nil : .relativeToXCConfig()),
-        .release(name: .release, xcconfig: isCI ? nil : .relativeToXCConfig()),
+        .debug(name: .debug, xcconfig: isCI ? nil : .relativeToXCConfig("Server/Debug")),
+        .release(name: .release, xcconfig: isCI ? nil : .relativeToXCConfig("Server/Release")),
       ]
     )
-
     let schemes: [Scheme] = [.makeScheme(target: .debug, name: name)]
 
     return Project(

--- a/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -18,7 +18,11 @@ public extension Project {
         .release(name: .release, xcconfig: isCI ? nil : .relativeToXCConfig("Server/Release")),
       ]
     )
-    let schemes: [Scheme] = [.makeScheme(target: .debug, name: name)]
+
+    let schemes: [Scheme] = [
+      .makeScheme(target: .debug, targetName: name, schemeName: "\(name)-Debug"),
+      .makeScheme(target: .release, targetName: name, schemeName: "\(name)-Release")
+    ]
 
     return Project(
       name: name,
@@ -34,15 +38,15 @@ public extension Project {
 
 extension Scheme {
   /// Scheme을 만드는 메소드
-  static func makeScheme(target: ConfigurationName, name: String) -> Scheme {
+  static func makeScheme(target: ConfigurationName, targetName: String, schemeName: String) -> Scheme {
     return Scheme(
-      name: name,
+      name: schemeName,
       shared: true,
-      buildAction: .buildAction(targets: ["\(name)"]),
+      buildAction: .buildAction(targets: ["\(targetName)"]),
       testAction: .targets(
-        ["\(name)Tests"],
+        ["\(targetName)Tests"],
         configuration: target,
-        options: .options(coverage: true, codeCoverageTargets: ["\(name)"])
+        options: .options(coverage: true, codeCoverageTargets: ["\(targetName)"])
       ),
       runAction: .runAction(configuration: target),
       archiveAction: .archiveAction(configuration: target),

--- a/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -3,6 +3,7 @@ import ProjectDescription
 import Foundation
 
 private let isCI = ProcessInfo.processInfo.environment["TUIST_CI"] != nil
+private let isDebug = ProcessInfo.processInfo.environment["TUIST_SCHEME"] == "DEBUG"
 
 public extension Project {
   static func makeModule(
@@ -19,10 +20,8 @@ public extension Project {
       ]
     )
 
-    let schemes: [Scheme] = [
-      .makeScheme(target: .debug, targetName: name, schemeName: "\(name)-Debug"),
-      .makeScheme(target: .release, targetName: name, schemeName: "\(name)-Release")
-    ]
+    let configurationName: ConfigurationName = isDebug ? .debug : .release
+    let schemes: [Scheme] = [.makeScheme(configuration: configurationName, name: name)]
 
     return Project(
       name: name,
@@ -38,20 +37,20 @@ public extension Project {
 
 extension Scheme {
   /// Scheme을 만드는 메소드
-  static func makeScheme(target: ConfigurationName, targetName: String, schemeName: String) -> Scheme {
+  static func makeScheme(configuration: ConfigurationName, name: String) -> Scheme {
     return Scheme(
-      name: schemeName,
+      name: name,
       shared: true,
-      buildAction: .buildAction(targets: ["\(targetName)"]),
+      buildAction: .buildAction(targets: ["\(name)"]),
       testAction: .targets(
-        ["\(targetName)Tests"],
-        configuration: target,
-        options: .options(coverage: true, codeCoverageTargets: ["\(targetName)"])
+        ["\(name)Tests"],
+        configuration: configuration,
+        options: .options(coverage: true, codeCoverageTargets: ["\(name)"])
       ),
-      runAction: .runAction(configuration: target),
-      archiveAction: .archiveAction(configuration: target),
-      profileAction: .profileAction(configuration: target),
-      analyzeAction: .analyzeAction(configuration: target)
+      runAction: .runAction(configuration: configuration),
+      archiveAction: .archiveAction(configuration: configuration),
+      profileAction: .profileAction(configuration: configuration),
+      analyzeAction: .analyzeAction(configuration: configuration)
     )
   }
 }

--- a/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/iOS/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -12,15 +12,17 @@ public extension Project {
     targets: [Target],
     packages: [Package] = []
   ) -> Project {
+    let settingConfigurations: [Configuration] =
+    if isCI { [.debug(name: .debug)] }
+    else if isDebug { [.debug(name: .debug, xcconfig: .relativeToXCConfig("Server/Debug"))] }
+    else { [.debug(name: .release, xcconfig: .relativeToXCConfig("Server/Release"))] }
+
     let settings: Settings = .settings(
       base: ["ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS": "YES"],
-      configurations: [
-        .debug(name: .debug, xcconfig: isCI ? nil : .relativeToXCConfig("Server/Debug")),
-        .release(name: .release, xcconfig: isCI ? nil : .relativeToXCConfig("Server/Release")),
-      ]
+      configurations: settingConfigurations
     )
 
-    let configurationName: ConfigurationName = isDebug ? .debug : .release
+    let configurationName: ConfigurationName = isDebug || isCI ? .debug : .release
     let schemes: [Scheme] = [.makeScheme(configuration: configurationName, name: name)]
 
     return Project(


### PR DESCRIPTION
## 고민, 과정, 근거 💬

배포 서버와 개발 서버가 분리되면서 저희 프로젝트에서도 개발과 릴리즈라는 두 갈래의 Configuration을 설정할 필요가 생겼습니다.
그래서 기존에 `Shared.xcconfig`에서 baseURL을 설정했던 것을 `Debug.xcconfig`, `Release.xcconfig`로 분리했습니다.
```
XCConfig
├── Server
│   ├── Debug.xcconfig
│   └── Release.xcconfig
└── Shared.xcconfig
```
release로 빌드하는 것과 debug로 빌드하는 것을 분리하기 위해 Scheme을 두 개씩 생성할까 고민했으나, Scheme의 개수가 n배로 증가하다보니 원하는 Scheme을 찾기 어렵다고 생각이 들었고, `Makefile`을 사용하여 release용 생성과 debug용 생성을 분리하는 게 낫다고 생각했습니다.
그래서 아래와 같이 만들었습니다.

- `make generate`: debug용으로 빌드합니다.
- `make release`: release용으로 빌드합니다.

항상 사용하는 `make generate`는 debug configuration을 가집니다. 하지만 실 배포 서버에서 테스트가 필요하다면 `make release`로 Xcode를 생성하기만 하면 됩니다.


## References 📋

1. [Adding a build configuration file to your project](https://developer.apple.com/documentation/xcode/adding-a-build-configuration-file-to-your-project)
2. [XcodeのTargetについてのTIPS](https://www.slideshare.net/ganbit1021/xcodetargettips)

---

- Closed: #295
