### PR TITLE
[GWL-300] 운동 세션 화면 버그 수정

### DIFF
--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewController.swift
@@ -37,6 +37,7 @@ final class WorkoutSessionContainerViewController: UIViewController {
   private lazy var pageViewController: UIPageViewController = {
     let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
     pageViewController.dataSource = self
+    pageViewController.delegate = self
     return pageViewController
   }()
 
@@ -214,7 +215,6 @@ extension WorkoutSessionContainerViewController: UIPageViewControllerDataSource 
     guard viewControllers.count > previousIndex else {
       return nil
     }
-    pageControl.select(at: previousIndex)
     return viewControllers[previousIndex]
   }
 
@@ -233,8 +233,19 @@ extension WorkoutSessionContainerViewController: UIPageViewControllerDataSource 
     guard viewControllersCount > nextIndex else {
       return nil
     }
-    pageControl.select(at: nextIndex)
     return viewControllers[nextIndex]
+  }
+}
+
+// MARK: UIPageViewControllerDelegate
+
+extension WorkoutSessionContainerViewController: UIPageViewControllerDelegate {
+  func pageViewController(_: UIPageViewController, didFinishAnimating _: Bool, previousViewControllers _: [UIViewController], transitionCompleted completed: Bool) {
+    if completed,
+       let visibleViewController = pageViewController.viewControllers?.first,
+       let index = viewControllers.firstIndex(of: visibleViewController) {
+      pageControl.select(at: index)
+    }
   }
 }
 

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/WorkoutSessionContainerViewModel.swift
@@ -88,7 +88,7 @@ extension WorkoutSessionContainerViewModel: WorkoutSessionContainerViewModelRepr
     let mapURLPublisher = input.mapCaptureImageDataPublisher
       .flatMap(imageUploadUseCase.uploadImage(included:))
       .catch { _ in Just(URL(string: "https://gblafytgdduy20857289.cdn.ntruss.com/30ab314b-a59a-44c8-b9c5-44d94b4542f0.png")!) }
-      .eraseToAnyPublisher()
+      .share()
 
     let recordPublisher = mapURLPublisher
       .withLatestFrom(input.locationPublisher) {
@@ -109,6 +109,7 @@ extension WorkoutSessionContainerViewModel: WorkoutSessionContainerViewModelRepr
         return workoutData
       }
       .flatMap(workoutRecordUseCase.record)
+      .share()
 
     recordPublisher
       .receive(on: RunLoop.main)


### PR DESCRIPTION
## Screenshots 📸

|Page Control 애니메이션 움직이지 않았던 버그 수정|
|:-:|
|![RPReplay_Final1702110315](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/e322fad3-95d4-4e40-b445-d0275efddde5)|

<br/><br/>

## 고민, 과정, 근거 💬

운동 세션 화면에서 제대로 동작하지 않았던 버그를 수정했습니다.

1. 기록 API가 두 번 호출되는 버그를 고쳤습니다.
   - 계속해서 새로운 구독이 생기게 되어 API 흐름이 여러번 호출되는 문제가 있었습니다. 하나의 흐름으로 처리해야 했기에 `share()` 오퍼레이터를 추가하여 해결했습니다.
2. pageControl이 동작하지 않았던 버그를 고쳤습니다.
   - `PageViewControllerDataSource`에 넣어두었던 pageControl 이동 코드를 `PageViewControllerDelegate`로 이동해서 고쳤습니다.

---

- Closed: #300
