### PR TITLE
[GWL-298] 닉네임 중복 검사 api

### DIFF
--- a/BackEnd/src/auth/auth.service.ts
+++ b/BackEnd/src/auth/auth.service.ts
@@ -47,11 +47,7 @@ export class AuthService {
   }
 
   async registerWithUserIdAndProvider(signupInfo: SignupDto) {
-    if (
-      await this.profilesService.validateProfileNickname(signupInfo.nickname)
-    ) {
-      throw new NicknameDuplicateException();
-    }
+    await this.profilesService.validateProfileNickname(signupInfo.nickname);
     const newUser = await this.usersService.createUser(signupInfo);
 
     return this.loginUser(newUser.profile.publicId);

--- a/BackEnd/src/profiles/dto/get-nickname-availability.dto.ts
+++ b/BackEnd/src/profiles/dto/get-nickname-availability.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from "@nestjs/swagger";
+import { Profile } from "../entities/profiles.entity";
+
+export class GetNicknameAvailAbailityDto extends PickType(Profile, ['nickname']) {}

--- a/BackEnd/src/profiles/profiles.controller.ts
+++ b/BackEnd/src/profiles/profiles.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Patch,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -22,6 +23,7 @@ import { AccessTokenGuard } from '../auth/guard/bearerToken.guard';
 import { GetProfileResponseDto } from './dto/get-profile-response.dto';
 import { PaginateProfilePostDto } from './dto/paginate-profile-post.dto';
 import { GetProfilePostsResponseDto } from './dto/get-profile-posts-response.dto';
+import { GetNicknameAvailAbailityDto } from './dto/get-nickname-availability.dto';
 
 @ApiTags('Profiles API')
 @Controller('api/v1/profiles')
@@ -77,5 +79,12 @@ export class ProfilesController {
     @Query() query: PaginateProfilePostDto,
   ) {
     return this.profilesService.getProfilePosts(publicId, query);
+  }
+
+  @ApiOperation({ summary: '닉네임 중복 검사한다.' })
+  @Post('nickname-availability')
+  getNicknameAvailability(@Body() body: GetNicknameAvailAbailityDto) {
+    this.profilesService.validateProfileNickname(body.nickname);
+    return null;
   }
 }

--- a/BackEnd/src/profiles/profiles.controller.ts
+++ b/BackEnd/src/profiles/profiles.controller.ts
@@ -84,7 +84,6 @@ export class ProfilesController {
   @ApiOperation({ summary: '닉네임 중복 검사한다.' })
   @Post('nickname-availability')
   getNicknameAvailability(@Body() body: GetNicknameAvailAbailityDto) {
-    this.profilesService.validateProfileNickname(body.nickname);
-    return null;
+    return this.profilesService.validateProfileNickname(body.nickname);
   }
 }

--- a/BackEnd/src/profiles/profiles.service.ts
+++ b/BackEnd/src/profiles/profiles.service.ts
@@ -38,6 +38,7 @@ export class ProfilesService {
     if(result) {
       throw new NicknameDuplicateException();
     }
+    return null;
   }
 
   async getProfile(publicId: string) {

--- a/BackEnd/src/profiles/profiles.service.ts
+++ b/BackEnd/src/profiles/profiles.service.ts
@@ -20,9 +20,7 @@ export class ProfilesService {
   ) {}
 
   async updateProfile(publicId: string, updateProfileDto: UpdateProfileDto) {
-    if (await this.validateProfileNickname(updateProfileDto.nickname)) {
-      throw new NicknameDuplicateException();
-    }
+    await this.validateProfileNickname(updateProfileDto.nickname);
     await this.profilesRepository.update({ publicId }, updateProfileDto);
     return this.getProfile(publicId);
   }
@@ -32,11 +30,14 @@ export class ProfilesService {
   }
 
   async validateProfileNickname(nickname: string) {
-    return await this.profilesRepository.exist({
+    const result = await this.profilesRepository.exist({
       where: {
         nickname,
       },
     });
+    if(result) {
+      throw new NicknameDuplicateException();
+    }
   }
 
   async getProfile(publicId: string) {


### PR DESCRIPTION
## 고민, 과정, 근거 💬
`api/v1/profiles/nickname-availability` Post 요청
- nickname 중복시 
```json
{
    "code": 2010,
    "errorMessage": "duplicated nickname error.",
    "data": null
}
```

- 사용할 수 있는 nickname이라면
```json
{
    "code": null,
    "errorMessage": null,
    "data": null
}
```
---

- Closed: #298 
