### PR TITLE
[GWL-303] 로고 추가된 로그인 화면 UI 작성

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -22,11 +22,12 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     window = UIWindow(windowScene: windowScene)
 
     let navigationController = UINavigationController()
+    let coordinator = LoginFeatureCoordinator(navigationController: navigationController, isMockEnvironment: false, isMockFirst: false)
     window?.rootViewController = navigationController
-    let coordinator = AppCoordinator(navigationController: navigationController)
-    coordinating = coordinator
+//    let coordinator = AppCoordinator(navigationController: navigationController)
+//    coordinating = coordinator
+//    coordinator.start()
     coordinator.start()
-    window?.rootViewController = navigationController
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -25,7 +25,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     let coordinator = AppCoordinator(navigationController: navigationController)
     coordinating = coordinator
     coordinator.start()
-    coordinator.start()
     window?.makeKeyAndVisible()
   }
 }

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -20,13 +20,11 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
   func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
     guard let windowScene = scene as? UIWindowScene else { return }
     window = UIWindow(windowScene: windowScene)
-
     let navigationController = UINavigationController()
-    let coordinator = LoginFeatureCoordinator(navigationController: navigationController, isMockEnvironment: false, isMockFirst: false)
     window?.rootViewController = navigationController
-//    let coordinator = AppCoordinator(navigationController: navigationController)
-//    coordinating = coordinator
-//    coordinator.start()
+    let coordinator = AppCoordinator(navigationController: navigationController)
+    coordinating = coordinator
+    coordinator.start()
     coordinator.start()
     window?.makeKeyAndVisible()
   }

--- a/iOS/Projects/Features/Login/Sources/Presentation/LoginScene/LoginViewController.swift
+++ b/iOS/Projects/Features/Login/Sources/Presentation/LoginScene/LoginViewController.swift
@@ -38,7 +38,7 @@ final class LoginViewController: UIViewController {
 
   private let policyTextView: UITextView = {
     let attributedString = NSMutableAttributedString(string: "가입을 진행할 경우, 서비스 약관 및\n개인정보 처리방침에 동의한것으로 간주합니다.")
-    attributedString.addAttribute(.link, value: "https://borabong.tistory.com/18", range: NSRange(location: 12, length: 15))
+    attributedString.addAttribute(.link, value: PrivacyLink.link, range: NSRange(location: 12, length: 15))
 
     let textView = UITextView()
     textView.translatesAutoresizingMaskIntoConstraints = false
@@ -188,4 +188,10 @@ extension LoginViewController: ASAuthorizationControllerPresentationContextProvi
   ) -> ASPresentationAnchor {
     return view.window!
   }
+}
+
+// MARK: - PrivacyLink
+
+private enum PrivacyLink {
+  static let link = "https://www.notion.so/geul-woll/207b7ec2bf544a199541d9d916efa17f?pvs=4"
 }

--- a/iOS/Projects/Features/Login/Sources/Presentation/LoginScene/LoginViewController.swift
+++ b/iOS/Projects/Features/Login/Sources/Presentation/LoginScene/LoginViewController.swift
@@ -9,6 +9,7 @@
 import AuthenticationServices
 import Combine
 import CombineCocoa
+import DesignSystem
 import Log
 import UIKit
 
@@ -21,10 +22,36 @@ final class LoginViewController: UIViewController {
   private let credentialSubject = PassthroughSubject<AuthorizationInfo, Never>()
   private let loginSubject = PassthroughSubject<Void, Never>()
 
+  private lazy var logoImageView: UIImageView = {
+    let imageView = UIImageView()
+    imageView.translatesAutoresizingMaskIntoConstraints = false
+    imageView.image = .logoImage
+    imageView.contentMode = .scaleAspectFit
+    return imageView
+  }()
+
   private lazy var appleLoginButton: ASAuthorizationAppleIDButton = {
     let button = ASAuthorizationAppleIDButton(type: .signIn, style: .black)
     button.translatesAutoresizingMaskIntoConstraints = false
     return button
+  }()
+
+  private let policyTextView: UITextView = {
+    let attributedString = NSMutableAttributedString(string: "가입을 진행할 경우, 서비스 약관 및\n개인정보 처리방침에 동의한것으로 간주합니다.")
+    attributedString.addAttribute(.link, value: "https://borabong.tistory.com/18", range: NSRange(location: 12, length: 15))
+
+    let textView = UITextView()
+    textView.translatesAutoresizingMaskIntoConstraints = false
+    textView.attributedText = attributedString
+    textView.isEditable = false
+    textView.isScrollEnabled = false
+    textView.attributedText = attributedString
+    textView.dataDetectorTypes = .link
+    textView.font = .systemFont(ofSize: 12, weight: .medium)
+    textView.textColor = DesignSystemColor.primaryText
+    textView.textAlignment = .center
+    textView.backgroundColor = DesignSystemColor.secondaryBackground
+    return textView
   }()
 
   init(viewModel: LoginViewModelRepresentable) {
@@ -49,17 +76,42 @@ final class LoginViewController: UIViewController {
 
 private extension LoginViewController {
   func configureUI() {
-    view.backgroundColor = .systemBackground
+    view.backgroundColor = DesignSystemColor.secondaryBackground
 
     let safeArea = view.safeAreaLayoutGuide
+
+    view.addSubview(logoImageView)
+    NSLayoutConstraint.activate([
+      logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+      logoImageView.bottomAnchor.constraint(equalTo: view.centerYAnchor),
+      logoImageView.widthAnchor.constraint(equalToConstant: Metrics.imageViewSize),
+      logoImageView.heightAnchor.constraint(equalToConstant: Metrics.imageViewSize),
+    ])
+
     view.addSubview(appleLoginButton)
     NSLayoutConstraint.activate([
       appleLoginButton.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.componentInterval),
-      appleLoginButton.topAnchor.constraint(equalTo: safeArea.topAnchor, constant: Metrics.componentInterval),
+      appleLoginButton.topAnchor.constraint(equalTo: logoImageView.bottomAnchor, constant: Metrics.logoButtonInterval),
       appleLoginButton.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor, constant: -Metrics.componentInterval),
       appleLoginButton.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
     ])
+
+    view.addSubview(policyTextView)
+    NSLayoutConstraint.activate([
+      policyTextView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor, constant: -Metrics.buttonPolicyInterval),
+      policyTextView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+    ])
   }
+}
+
+// MARK: - Metrics
+
+private enum Metrics {
+  static let componentInterval: CGFloat = 51
+  static let buttonHeight: CGFloat = 42
+  static let imageViewSize: CGFloat = 200
+  static let logoButtonInterval: CGFloat = 200
+  static let buttonPolicyInterval: CGFloat = 30
 }
 
 private extension LoginViewController {
@@ -108,13 +160,6 @@ private extension LoginViewController {
     authorizationController.presentationContextProvider = self
     authorizationController.performRequests()
   }
-}
-
-// MARK: - Metrics
-
-private enum Metrics {
-  static let componentInterval: CGFloat = 51
-  static let buttonHeight: CGFloat = 50
 }
 
 // MARK: - LoginViewController + ASAuthorizationControllerDelegate


### PR DESCRIPTION
## Screenshots 📸

### 라이트 모드
|iPhone 15 Pro|iPhone SE|
|:-:|:-:|
|<img src="https://github.com/JongPyoAhn/Python/assets/68585628/b312c199-bd45-471e-8d97-39f93f87ca07">|<img src="https://github.com/JongPyoAhn/Python/assets/68585628/2998e198-8d77-47d6-b72f-5a4ef81b4eaa">

### 다크 모드
|iPhone 15 Pro|iPhone SE|
|:-:|:-:|
|<img src="https://github.com/JongPyoAhn/Python/assets/68585628/45696605-e69a-4c0c-ab2a-4be773161e3c">|<img src="https://github.com/JongPyoAhn/Python/assets/68585628/30969eb7-a152-4ec5-bd4a-4a9ebd909681">
<br/><br/>

## 고민, 과정, 근거 💬
- 레이블에 링크를 어떻게 넣고 부분부분 파란색을 어떻게 칠하지..?
    - NSMutableAttributedString을 사용하면 NSRange를 통해 원하는 하이퍼링크 색상(파란색)으로 문자의 범위를 색칠할 수 있다. 또한, textView를 사용해서 dataDetectorTypes를 link로 설정해주면 NSMutableAttributedString을 통해 링크로 설정한 글씨를 누르면 링크를 이동하도록 할 수 있다.

<br/><br/>

## References 📋
- [텍스트뷰의 텍스트 내 링크 하이퍼링크로 연결하기](https://borabong.tistory.com/18)

<br/><br/>

---

- Closed: #303 
