### PR TITLE
[Feat]: WorkoutEnvironmentViewController  popGestgure 버그 수정

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/CommonScene/Coordinator/AppCoordinator.swift
+++ b/iOS/Projects/App/WeTri/Sources/CommonScene/Coordinator/AppCoordinator.swift
@@ -28,7 +28,7 @@ final class AppCoordinator: AppCoordinating {
   }
 
   func start() {
-    showSplashFlow()
+    showTabBarFlow()
   }
 
   private func showSplashFlow() {

--- a/iOS/Projects/App/WeTri/Sources/CommonScene/Coordinator/AppCoordinator.swift
+++ b/iOS/Projects/App/WeTri/Sources/CommonScene/Coordinator/AppCoordinator.swift
@@ -28,7 +28,7 @@ final class AppCoordinator: AppCoordinating {
   }
 
   func start() {
-    showTabBarFlow()
+    showSplashFlow()
   }
 
   private func showSplashFlow() {

--- a/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutEnvironmentSetUpCoordinator.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutEnvironmentSetUpCoordinator.swift
@@ -37,6 +37,7 @@ final class WorkoutEnvironmentSetUpCoordinator: WorkoutEnvironmentSetUpCoordinat
     let repository = WorkoutEnvironmentSetupNetworkRepository(session: URLSession.shared)
 
     let useCase = WorkoutEnvironmentSetupUseCase(repository: repository)
+
     let userInfoUseCase = UserInformationUseCase()
 
     let viewModel = WorkoutEnvironmentSetupViewModel(
@@ -46,8 +47,9 @@ final class WorkoutEnvironmentSetUpCoordinator: WorkoutEnvironmentSetUpCoordinat
     )
 
     let viewController = WorkoutEnvironmentSetupViewController(viewModel: viewModel)
+    viewController.hidesBottomBarWhenPushed = true
 
-    navigationController.pushViewController(viewController, animated: false)
+    navigationController.pushViewController(viewController, animated: true)
   }
 
   func pushPeerRandomMatchingViewController(workoutSetting: WorkoutSetting) {

--- a/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
@@ -176,7 +176,7 @@ final class WorkoutSessionCoordinator: WorkoutSessionCoordinating {
     let viewModel = CountDownBeforeWorkoutViewModel(coordinator: self, useCase: useCase)
 
     let viewController = CountDownBeforeWorkoutViewController(viewModel: viewModel)
-    navigationController.pushViewController(viewController, animated: true)
+    navigationController.setViewControllers([viewController], animated: true)
   }
 
   func pushTapBarViewController() {

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutEnvironmentSetupViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutEnvironmentSetupViewController.swift
@@ -72,6 +72,7 @@ public final class WorkoutEnvironmentSetupViewController: UIViewController {
       .compactMap { $0 as? UIScrollView }
       .first
     pageScrollView = scrollView
+    pageScrollView?.isScrollEnabled = false
     pageScrollView?.delegate = self
 
     pageViewController.view.translatesAutoresizingMaskIntoConstraints = false
@@ -81,11 +82,21 @@ public final class WorkoutEnvironmentSetupViewController: UIViewController {
 
 private extension WorkoutEnvironmentSetupViewController {
   func setup() {
-    view.backgroundColor = DesignSystemColor.primaryBackground
+    setupStyle()
     setupViewHierarchyAndConstraints()
     bind()
 
     configureDataSource()
+  }
+
+  func setupStyle() {
+    navigationController?.isNavigationBarHidden = false
+    navigationController?.navigationBar.isHidden = false
+    navigationController?.navigationBar.tintColor = DesignSystemColor.main03
+
+    let titleBarButtonItemFont: UIFont = .preferredFont(forTextStyle: .title3, weight: .semibold)
+    navigationController?.tabBarItem.setTitleTextAttributes([.font: titleBarButtonItemFont], for: .normal)
+    view.backgroundColor = DesignSystemColor.primaryBackground
   }
 
   func setupViewHierarchyAndConstraints() {
@@ -253,6 +264,7 @@ extension WorkoutEnvironmentSetupViewController: UIPageViewControllerDelegate, U
     if
       let currentViewController = pageViewController.viewControllers?.first,
       let currentIndex = contentViewControllers.firstIndex(of: currentViewController) {
+      pageScrollView?.isScrollEnabled = currentIndex == 0 ? false : true
       gwPageControl.select(at: currentIndex)
     }
   }
@@ -273,22 +285,11 @@ extension WorkoutEnvironmentSetupViewController: UIPageViewControllerDelegate, U
   }
 }
 
-// MARK: UIScrollViewDelegate
-
-extension WorkoutEnvironmentSetupViewController: UIScrollViewDelegate {
-  public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
-    if pageViewController.viewControllers?.first == contentViewControllers.first {
-      scrollView.isScrollEnabled = false
-    }
-  }
-
-  public func scrollViewDidEndDragging(_: UIScrollView, willDecelerate _: Bool) {}
-}
-
 // MARK: WorkoutSelectViewDelegate
 
 extension WorkoutEnvironmentSetupViewController: WorkoutSelectViewDelegate {
   func nextButtonDidTap() {
+    pageScrollView?.isScrollEnabled = false
     gwPageControl.next()
     pageViewController.setViewControllers([workoutPeerSelectViewController], direction: .forward, animated: true) { [weak self] _ in
       self?.pageScrollView?.isScrollEnabled = true

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutEnvironmentSetupViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutEnvironmentSetupViewController.swift
@@ -32,24 +32,24 @@ public final class WorkoutEnvironmentSetupViewController: UIViewController {
   }
 
   private var subscriptions = Set<AnyCancellable>()
-  private var viewModel: WorkoutEnvironmentSetupViewModelRepresentable?
+  private let viewModel: WorkoutEnvironmentSetupViewModelRepresentable?
 
   // MARK: - WorkoutEnvironmentSetupViewModelInput
 
-  let requestWorkoutTypes = PassthroughSubject<Void, Never>()
-  let requestWorkoutPeerTypes = PassthroughSubject<Void, Never>()
-  let selectWorkoutType = PassthroughSubject<WorkoutType?, Never>()
-  let selectPeerType = PassthroughSubject<PeerType?, Never>()
-  let endWorkoutEnvironment = PassthroughSubject<Void, Never>()
-  let didTapStartButton = PassthroughSubject<Void, Never>()
+  private let requestWorkoutTypes = PassthroughSubject<Void, Never>()
+  private let requestWorkoutPeerTypes = PassthroughSubject<Void, Never>()
+  private let selectWorkoutType = PassthroughSubject<WorkoutType?, Never>()
+  private let selectPeerType = PassthroughSubject<PeerType?, Never>()
+  private let endWorkoutEnvironment = PassthroughSubject<Void, Never>()
+  private let didTapStartButton = PassthroughSubject<Void, Never>()
 
   // MARK: - ConatinerViewController Control Property
 
-  var workoutTypesDataSource: UICollectionViewDiffableDataSource<Int, WorkoutType>?
-  var workoutPeerTypesDataSource: UICollectionViewDiffableDataSource<Int, PeerType>?
+  private var workoutTypesDataSource: UICollectionViewDiffableDataSource<Int, WorkoutType>?
+  private var workoutPeerTypesDataSource: UICollectionViewDiffableDataSource<Int, PeerType>?
 
-  var workoutTypesCollectionView: UICollectionView?
-  var workoutPeerTypesCollectionView: UICollectionView?
+  private var workoutTypesCollectionView: UICollectionView?
+  private var workoutPeerTypesCollectionView: UICollectionView?
 
   private let workoutSelectViewController = WorkoutSelectViewController()
   private let workoutPeerSelectViewController = WorkoutPeerSelectViewController()
@@ -63,7 +63,7 @@ public final class WorkoutEnvironmentSetupViewController: UIViewController {
     return pageControl
   }()
 
-  lazy var pageViewController: UIPageViewController = {
+  private lazy var pageViewController: UIPageViewController = {
     let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
     pageViewController.dataSource = self
     pageViewController.delegate = self

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutSelectViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutSelectViewController.swift
@@ -22,7 +22,6 @@ protocol WorkoutSelectViewDelegate: AnyObject {
 final class WorkoutSelectViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
-    navigationController?.setNavigationBarHidden(true, animated: false)
     setupConstraints()
     bind()
   }
@@ -32,7 +31,7 @@ final class WorkoutSelectViewController: UIViewController {
 
   private let workoutSelectDescriptionLabel: UILabel = {
     let label = UILabel()
-    label.font = .preferredFont(forTextStyle: .title1, with: .traitBold)
+    label.font = .preferredFont(forTextStyle: .title1, weight: .bold)
     label.textAlignment = .left
     label.text = "1. 운동을 선택하세요"
 


### PR DESCRIPTION
## Screenshots 📸

|Name|
|:-:|
|![Simulator Screen Recording - iPhone 15 Pro - 2023-12-10 at 11 49 28](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/d0a7a4ea-fca2-4eee-a50d-9052b56a1085)|

<br/><br/>

## 고민, 과정, 근거 💬

### PgaeViewController파보기
- PageViewController를 보면 내부에 `ScrollView`가 존재...
- 그래서 어떤 화면에서는 반드시 ScrollView의 isScrollEnabled을 건드려 줘야 했음.
- 문제 상황은 다음과 같음
  - 첫번 째 화면에서 스크롤이 가능하면 안됨
  - 두번 째 화면에서 스크롤이 가능해야 함
- 이대로 만들었는데 문제는, 첫번째 화면에서 스크롤 했을 때 다음 버튼을 연타하면 앱이 깨졌음
  - 그래서 이유를 확인해 보니 Scroll애니메이션 도중에 isScrollEnabled가 true로 바뀌어 예상치 못한 흐름으로 흘러갔음.
- setViewControllers내부에, completionHandler를 처리하여 안전하게 처리
```swift 
 func nextButtonDidTap() {
    pageScrollView?.isScrollEnabled = false
    gwPageControl.next()
    pageViewController.setViewControllers([workoutPeerSelectViewController], direction: .forward, animated: true) { [weak self] _ in
      self?.pageScrollView?.isScrollEnabled = true
    }
  }

```
<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #316
