### PR TITLE
[GWL-331] LocationData가 Polyline을 그릴 수 없을 만큼 데이터 갯수가 작을 때 FatalError가 발생하는 버그 수정

### DIFF
--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
@@ -223,7 +223,7 @@ final class WorkoutRouteMapViewController: UIViewController {
   }
 
   private func updatePolyLine(_ value: KalmanFilterCensored?) {
-    // 칼만 필터가 초기값이 튀기 때문에, 다음과 같이 Location의 갯수가 3 이하인 경우 폴리라인을 그리지 않습니다.
+    // 칼만 필터가 초기값이 튀기 때문에, 다음과 같이 Location의 갯수가 4 이하인 경우 폴리라인을 그리지 않습니다.
     guard
       let value,
       locations.count > 4

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
@@ -157,7 +157,13 @@ final class WorkoutRouteMapViewController: UIViewController {
   }
 
   /// 스냅샷을 찍습니다. 거리의 위도 경도중 가장 큰값과 작은값을 적절하게 조합해서 사이즈를 만듭니다.
+  ///
+  /// 만약 스냅샷을 통해서 만들 Location의 데이터가 갯수가 적다면, mapCaptureDataSubject에 nil을 전송합니다.
   private func createMapSnapshot(with regionData: MapRegion) {
+    if locations.count < Constants.minimumAmountLocationCount {
+      locations = Constants.defaultPolyLineLocationList.map { .init(latitude: $0[0], longitude: $0[1]) }
+    }
+
     let coordinates = locations.map(\.coordinate)
     let polyLine = MKPolyline(coordinates: coordinates, count: coordinates.count)
     let span = MKCoordinateSpan(
@@ -200,7 +206,10 @@ final class WorkoutRouteMapViewController: UIViewController {
 
       self?.locations
         .forEach { location in
-          let currentCLLocationCoordinator2D = CLLocationCoordinate2D(latitude: location.coordinate.latitude, longitude: location.coordinate.longitude)
+          let currentCLLocationCoordinator2D = CLLocationCoordinate2D(
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude
+          )
 
           // snapshot에서 현재 위도 경도에 대한 데이터가 어느 CGPoint에 있는지 찾아내고, 이를 Polyline을 그립니다.
           context.cgContext.addLine(to: snapshot.point(for: currentCLLocationCoordinator2D))
@@ -214,7 +223,13 @@ final class WorkoutRouteMapViewController: UIViewController {
   }
 
   private func updatePolyLine(_ value: KalmanFilterCensored?) {
-    guard let value else { return }
+    // 칼만 필터가 초기값이 튀기 때문에, 다음과 같이 Location의 갯수가 3 이하인 경우 폴리라인을 그리지 않습니다.
+    guard
+      let value,
+      locations.count > 4
+    else {
+      return
+    }
 
     let currentLocation = CLLocation(latitude: value.latitude, longitude: value.longitude)
     locations.append(currentLocation)
@@ -324,6 +339,12 @@ extension WorkoutRouteMapViewController: MKMapViewDelegate {
 // MARK: WorkoutRouteMapViewController.Metrics
 
 private extension WorkoutRouteMapViewController {
+  enum Constants {
+    static let minimumAmountLocationCount: Int = 5
+
+    static let defaultPolyLineLocationList: [[Double]] = [[37.559986, 126.975230]]
+  }
+
   enum Metrics {
     static let mapDistance: CLLocationDistance = 500
     static let horizontal: CGFloat = 24

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
@@ -342,7 +342,7 @@ private extension WorkoutRouteMapViewController {
   enum Constants {
     static let minimumAmountLocationCount: Int = 5
 
-    static let defaultPolyLineLocationList: [[Double]] = [[37.559986, 126.975230]]
+    static let defaultPolyLineLocationList: [[Double]] = [[37.22738768300735, 127.06500224609061]]
   }
 
   enum Metrics {

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewModel.swift
@@ -60,7 +60,6 @@ extension WorkoutRouteMapViewModel: WorkoutRouteMapViewModelRepresentable {
 
     input
       .filterShouldUpdateHeadingPublisher
-      .dropFirst(4)
       .sink { [kalmanUseCase] value in
         kalmanUseCase.updateHeading(value)
       }

--- a/iOS/Projects/Shared/CommonNetworkingKeyManager/Sources/TNKeychainInterceptor.swift
+++ b/iOS/Projects/Shared/CommonNetworkingKeyManager/Sources/TNKeychainInterceptor.swift
@@ -44,7 +44,6 @@ extension TNKeychainInterceptor: TNRequestInterceptor {
     response: URLResponse,
     delegate _: URLSessionDelegate?
   ) async throws -> (Data, URLResponse) {
-    Log.make().debug("\(String(data: data, encoding: .utf8)!)")
     let code = try decoder.decode(GWResponse<EmptyModel>.self, from: data).code
     if code == 1030 {
       Log.make().debug("AccessToken이 만료되어, Retry를 진행합니다.")


### PR DESCRIPTION
## Screenshots 📸

|Name|
|:-:|
|(image here)|

<br/><br/>

## 고민, 과정, 근거 💬

### 운동 기록 할 만큼 위치 값이 없을 때 초기값 지정을 통해서 버그를 수정
- `static let defaultPolyLineLocationList: [[Double]] = [[37.559986, 126.975230]]`
- @WhiteHyun 에게 폴리라인이 한개 일 때 발생하는 현상에 대해서 전달


<br/><br/>



## References 📋


<br/><br/>

---

- Closed: #331
