### PR TITLE
[GWL-334] 카운트다운 화면, WorkoutSession, WorkoutSummery 화면에서 TabBar 보이는 버그 수정

### DIFF
--- a/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/RecordFeatureCoordinator.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/RecordFeatureCoordinator.swift
@@ -95,6 +95,7 @@ extension RecordFeatureCoordinator: CoordinatorFinishDelegate {
 
 extension RecordFeatureCoordinator: WorkoutSettingCoordinatorFinishDelegate {
   func workoutSettingCoordinatorDidFinished(workoutSessionComponents: WorkoutSessionComponents) {
+    childCoordinators.removeAll()
     navigationController.dismiss(animated: false)
     showWorkoutFlow(workoutSessionComponents)
   }
@@ -104,6 +105,7 @@ extension RecordFeatureCoordinator: WorkoutSettingCoordinatorFinishDelegate {
 
 extension RecordFeatureCoordinator: WorkoutSessionFinishDelegate {
   public func moveToMainRecord() {
+    childCoordinators.removeAll()
     start()
   }
 }

--- a/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
@@ -175,7 +175,7 @@ final class WorkoutSessionCoordinator: WorkoutSessionCoordinating {
     )
     viewController.hidesBottomBarWhenPushed = true
 
-    navigationController.pushViewController(viewController, animated: true)
+    navigationController.setViewControllers([viewController], animated: true)
   }
 
   func pushWorkoutSummaryViewController(recordID: Int) {

--- a/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/Common/Coordinator/WorkoutSessionCoordinator.swift
@@ -173,6 +173,8 @@ final class WorkoutSessionCoordinator: WorkoutSessionCoordinating {
       healthDataProtocol: sessionViewController,
       locationTrackingProtocol: routeMapViewController
     )
+    viewController.hidesBottomBarWhenPushed = true
+
     navigationController.pushViewController(viewController, animated: true)
   }
 
@@ -189,6 +191,8 @@ final class WorkoutSessionCoordinator: WorkoutSessionCoordinating {
     let useCase = WorkoutSummaryUseCase(repository: repository, workoutRecordID: recordID)
     let viewModel = WorkoutSummaryViewModel(coordinating: self, workoutSummaryUseCase: useCase)
     let workoutSummaryViewController = WorkoutSummaryViewController(viewModel: viewModel)
+    workoutSummaryViewController.hidesBottomBarWhenPushed = true
+
     navigationController.setViewControllers([workoutSummaryViewController], animated: true)
   }
 
@@ -199,6 +203,8 @@ final class WorkoutSessionCoordinator: WorkoutSessionCoordinating {
     let viewModel = CountDownBeforeWorkoutViewModel(coordinator: self, useCase: useCase)
 
     let viewController = CountDownBeforeWorkoutViewController(viewModel: viewModel)
+    viewController.hidesBottomBarWhenPushed = true
+
     navigationController.setViewControllers([viewController], animated: true)
   }
 

--- a/iOS/Projects/Features/Record/Sources/Presentation/CountDownBeforeWorkoutScene/ViewController/CountDownBeforeWorkoutViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/CountDownBeforeWorkoutScene/ViewController/CountDownBeforeWorkoutViewController.swift
@@ -93,6 +93,7 @@ private extension CountDownBeforeWorkoutViewController {
 
   func setupStyles() {
     view.backgroundColor = DesignSystemColor.primaryBackground
+    hidesBottomBarWhenPushed = true
   }
 
   func bindViewModel() {

--- a/iOS/Projects/Features/Record/Sources/Presentation/CountDownBeforeWorkoutScene/ViewModel/CountDownBeforeWorkoutViewModel.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/CountDownBeforeWorkoutScene/ViewModel/CountDownBeforeWorkoutViewModel.swift
@@ -37,10 +37,9 @@ protocol CountDownBeforeWorkoutViewModelRepresentable {
 final class CountDownBeforeWorkoutViewModel {
   // MARK: - Properties
 
-  weak var coordinator: WorkoutSessionCoordinating?
-  var timerUseCase: CountDownBeforeWorkoutStartTimerUseCaseRepresentable
+  private weak var coordinator: WorkoutSessionCoordinating?
+  private var timerUseCase: CountDownBeforeWorkoutStartTimerUseCaseRepresentable
   private var subscriptions: Set<AnyCancellable> = []
-  private var beforeWorkoutTimerSubject: CurrentValueSubject<String, Never> = .init("")
   init(coordinator: WorkoutSessionCoordinating, useCase: CountDownBeforeWorkoutStartTimerUseCaseRepresentable) {
     self.coordinator = coordinator
     timerUseCase = useCase

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutEnvironmentSetupViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutEnvironmentSetupViewController.swift
@@ -94,8 +94,6 @@ private extension WorkoutEnvironmentSetupViewController {
     navigationController?.navigationBar.isHidden = false
     navigationController?.navigationBar.tintColor = DesignSystemColor.main03
 
-    let titleBarButtonItemFont: UIFont = .preferredFont(forTextStyle: .title3, weight: .semibold)
-    navigationController?.tabBarItem.setTitleTextAttributes([.font: titleBarButtonItemFont], for: .normal)
     view.backgroundColor = DesignSystemColor.primaryBackground
   }
 

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutSelectViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutEnvironmentScene/ViewController/WorkoutSelectViewController.swift
@@ -26,7 +26,7 @@ final class WorkoutSelectViewController: UIViewController {
     bind()
   }
 
-  private var cancellables = Set<AnyCancellable>()
+  private var subscriptions = Set<AnyCancellable>()
   weak var delegate: WorkoutSelectViewDelegate?
 
   private let workoutSelectDescriptionLabel: UILabel = {
@@ -113,7 +113,7 @@ private extension WorkoutSelectViewController {
       .sink { [weak self] _ in
         self?.delegate?.nextButtonDidTap()
       }
-      .store(in: &cancellables)
+      .store(in: &subscriptions)
   }
 
   enum Metrics {

--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSessionGroupScene/RouteMapScene/WorkoutRouteMapViewController.swift
@@ -143,7 +143,9 @@ final class WorkoutRouteMapViewController: UIViewController {
 
     viewModel
       .transform(input: input)
-      .sink(receiveValue: render(state:))
+      .sink { [weak self] state in
+        self?.render(state: state)
+      }
       .store(in: &subscriptions)
   }
 


### PR DESCRIPTION
## Screenshots 📸

|버그|수정본|
|:-:|:-:|
|![RPReplay_Final1702200138](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/9fe20a04-61c5-447b-a595-92e42bbcb829)|![RPReplay_Final1702201492](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/ba740b59-d3e7-4eb3-9b75-122987852571)|


<br/><br/>

## 고민, 과정, 근거 💬

### 버그수정했습니다.

<br/>

### 결고 화면 첨부합니다.
|운동 결과 화면| 홈으로 눌렀을 때| 
|:-:|:-:|
|![Simulator Screenshot - iPhone 15 Pro - 2023-12-10 at 20 50 47](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/4194f319-91e5-453c-b049-9bc3cb045164)| ![Simulator Screenshot - iPhone 15 Pro - 2023-12-10 at 20 52 25](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/6f2fc8e3-8c51-4f47-8069-66d39f8fbefb) |


<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #334
