### PR TITLE
[GWL-332] 운동 요약 화면 중 경로 화면 확대되는 증상 수정

### DIFF
--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSummaryScene/WorkoutSummaryCardView.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutSummaryScene/WorkoutSummaryCardView.swift
@@ -212,21 +212,11 @@ final class WorkoutSummaryCardView: UIView {
 
     mapView.removeOverlays(mapView.overlays)
     mapView.addOverlay(polyline)
-    // 지도 뷰 업데이트
-    let latitudes = currentLocations.map(\.coordinate.latitude)
-    let longitudes = currentLocations.map(\.coordinate.longitude)
-    let maxLatitude = latitudes.max() ?? 0
-    let minLatitude = latitudes.min() ?? 0
-    let maxLongitude = longitudes.max() ?? 0
-    let minLongitude = longitudes.min() ?? 0
-    let region = MKCoordinateRegion(
-      center: .init(
-        latitude: (maxLatitude + minLatitude) / 2,
-        longitude: (maxLongitude + minLongitude) / 2
-      ),
-      span: .init()
-    )
-    mapView.setRegion(region, animated: true)
+
+    // Polyline을 기반으로 MapView의 visible map rect를 설정
+    let polylineBoundingMapRect = polyline.boundingMapRect
+    let adjustedRect = mapView.mapRectThatFits(polylineBoundingMapRect, edgePadding: UIEdgeInsets(top: 30, left: 30, bottom: 30, right: 30))
+    mapView.setVisibleMapRect(adjustedRect, animated: true)
   }
 }
 


### PR DESCRIPTION
## Screenshots 📸

|전|후|
|:-:|:-:|
|![IMG_74525BC252A9-1](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/2967e398-8586-4672-be21-44f296d90ebf)|![IMG_4DE3254A07D2-1](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/b5da5216-bacc-42ea-b288-2d19ef0ee00e)|

<br/><br/>

## 고민, 과정, 근거 💬

운동 요약화면을 볼 때 운동했던 거리가 그려지는 것을 볼 수 있는데, 패딩값을 주는 게 보기 좋아보일 것 같아 이를 수정했습니다.

---

- Closed: #332
