### PR TITLE
[GWL-320] ResponseCode에 따른 이미지 재설정 얼럿 추가

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/Application/AppDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/AppDelegate.swift
@@ -1,7 +1,5 @@
 import UIKit
 
-import Keychain
-
 @main
 final class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(

--- a/iOS/Projects/App/WeTri/Sources/TabBarScene/Coordinator/TabBarCoordinator.swift
+++ b/iOS/Projects/App/WeTri/Sources/TabBarScene/Coordinator/TabBarCoordinator.swift
@@ -63,7 +63,7 @@ final class TabBarCoordinator: TabBarCoordinating {
       recordCoordinator.start()
 
     case .profile:
-      let profileCoordinator = ProfileCoordinator(navigationController: pageNavigationViewController, isMockEnvironment: true)
+      let profileCoordinator = ProfileCoordinator(navigationController: pageNavigationViewController, isMockEnvironment: false)
       childCoordinators.append(profileCoordinator)
       profileCoordinator.finishDelegate = self
       profileCoordinator.start()

--- a/iOS/Projects/Features/SignUp/Sources/Data/Repository/ImageFormRepository.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Data/Repository/ImageFormRepository.swift
@@ -62,19 +62,24 @@ public final class ImageFormRepository: ImageFormRepositoryRepresentable {
     .decode(type: GWResponse<[ImageForm]>.self, decoder: JSONDecoder())
     .tryMap { gwResponse in
       guard let code = gwResponse.code else {
-        throw ImageFormRepositoryError.invalidResponseCode
+        return gwResponse.data
       }
       switch code {
       case ImageFormRepositoryError.notAccessObjectStorage.code:
         throw ImageFormRepositoryError.notAccessObjectStorage
+
       case ImageFormRepositoryError.notAccessGreenEye.code:
         throw ImageFormRepositoryError.notAccessGreenEye
+
       case ImageFormRepositoryError.invalidFileType.code:
         throw ImageFormRepositoryError.invalidFileType
+
       case ImageFormRepositoryError.fileSizeTooLarge.code:
         throw ImageFormRepositoryError.fileSizeTooLarge
+
       case ImageFormRepositoryError.invalidFileCountOrFieldName.code:
         throw ImageFormRepositoryError.invalidFileCountOrFieldName
+
       default:
         return gwResponse.data
       }

--- a/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
@@ -199,7 +199,7 @@ private extension SignUpProfileViewController {
     )
     let output = viewModel.transform(input: input)
     output
-      .subscribe(on: DispatchQueue.main)
+      .receive(on: DispatchQueue.main)
       .sink { [weak self] state in
         self?.render(state: state)
       }
@@ -242,15 +242,13 @@ private extension SignUpProfileViewController {
     }
   }
 
-  func showAlert(message: String) {
+  private func showAlert(message: String) {
     let alertVC = UIAlertController(
       title: "잘못된 접근입니다.",
       message: message,
       preferredStyle: .alert
     )
-    let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
-      alertVC.dismiss(animated: true)
-    }
+    let confirmAction = UIAlertAction(title: "확인", style: .default)
     alertVC.addAction(confirmAction)
     present(alertVC, animated: true, completion: nil)
   }
@@ -264,7 +262,7 @@ private extension SignUpProfileViewController {
     let alertVC = UIAlertController(
       title: "프로필 이미지 설정",
       message: "선택해주세요.",
-      preferredStyle: .alert
+      preferredStyle: .actionSheet
     )
     let cameraAction = UIAlertAction(title: "카메라", style: .default) { [weak self] _ in
       self?.cameraAuth()

--- a/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
@@ -195,7 +195,7 @@ private extension SignUpProfileViewController {
       imageButtonTap: imageButtonTapSubject.eraseToAnyPublisher(),
       imageSetting: imageSetSubject.eraseToAnyPublisher(),
       completeButtonTap: completeButtonTapSubject.eraseToAnyPublisher(),
-      genderBirth: genderBirthSubject.eraseToAnyPublisher()
+      genderBirth: genderBirthSubject.setFailureType(to: Error.self).eraseToAnyPublisher()
     )
     let output = viewModel.transform(input: input)
     output
@@ -223,10 +223,36 @@ private extension SignUpProfileViewController {
     case .failure:
       completionButton.isEnabled = false
     case let .customError(error):
-      Log.make().error("\(error)")
+      if let profileImageError = error as? ImageFormRepositoryError {
+        switch profileImageError {
+        case .notAccessObjectStorage:
+          showAlert(message: "앱의 상태가 불안정합니다.")
+        case .notAccessGreenEye:
+          showAlert(message: "건전한 사진을 부탁드립니다.")
+        case .invalidFileType:
+          showAlert(message: "사진 파일이 올바르지 않은 확장자입니다.")
+        case .fileSizeTooLarge:
+          showAlert(message: "파일의 크기가 너무 큽니다.")
+        default:
+          showAlert(message: "다시 시도 해주세요.")
+        }
+      }
     default:
       break
     }
+  }
+
+  func showAlert(message: String) {
+    let alertVC = UIAlertController(
+      title: "잘못된 접근입니다.",
+      message: message,
+      preferredStyle: .alert
+    )
+    let confirmAction = UIAlertAction(title: "확인", style: .default) { _ in
+      alertVC.dismiss(animated: true)
+    }
+    alertVC.addAction(confirmAction)
+    present(alertVC, animated: true, completion: nil)
   }
 }
 

--- a/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
@@ -223,6 +223,7 @@ private extension SignUpProfileViewController {
     case .failure:
       completionButton.isEnabled = false
     case let .customError(error):
+      Log.make().error("\(error)")
       if let profileImageError = error as? ImageFormRepositoryError {
         switch profileImageError {
         case .notAccessObjectStorage:


### PR DESCRIPTION
## Screenshots 📸

|결과 화면|
|:-:|
|<img src="https://github.com/JongPyoAhn/Python/assets/68585628/4dc2a781-6789-4da8-bffa-0504b000fb68">|

<br/><br/>

## 고민, 과정, 근거 💬
- ViewModel에서 이미 모든 코드를 구성해놓아서 Error를 VC까지 가져갈 방법이 없는것 같은데... 어떻게..?
    - 승현님이 알려주시는 방법대로 Publisher를 여러 갈래로 나누어서 처리할 수 있었습니다.

<br/><br/>

## References 📋
❌

<br/><br/>

---

- Closed: #320 
