### PR TITLE
[GWL-336] fix: appleSignIn 응답 값에 따른 http code 설정

### DIFF
--- a/BackEnd/src/auth/auth.controller.ts
+++ b/BackEnd/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Headers, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Headers, HttpCode, HttpException, HttpStatus, Post, Res, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RefreshTokenGuard } from './guard/bearerToken.guard';
 import { SignupDto } from './dto/signup.dto';
@@ -11,11 +11,12 @@ import {
 } from './dto/auth-response.dto';
 import { SignInDto } from './dto/signin.dto';
 import { SigninFirstResDto } from './dto/signinRedirectRes.dto';
+import { Response } from 'express';
 
 @ApiTags('Authentication')
 @Controller('api/v1/auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(private readonly authService: AuthService) { }
 
   @ApiOperation({ summary: '유저 회원가입' })
   @ApiBody({ description: 'The ID of the item', type: SignupDto })
@@ -85,6 +86,10 @@ export class AuthController {
   })
   @Post('apple/signin')
   async appleSignIn(@IdentityToken() token: string) {
-    return this.authService.appleSignIn(token);
+    const result = this.authService.appleSignIn(token);
+    // if (('isFirstLogined' in result)) {
+    //   throw new HttpException(result, HttpStatus.CREATED);
+    // } 
+    return result;
   }
 }

--- a/BackEnd/src/auth/auth.service.ts
+++ b/BackEnd/src/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { Redis } from 'ioredis';
 import { AuthAppleService } from './auth-apple.service';
-import { Inject, Injectable } from '@nestjs/common';
+import { HttpException, Inject, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ProfilesService } from '../profiles/profiles.service';
 import { UsersService } from '../users/users.service';
@@ -9,6 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 import {
   InvalidTokenException,
   NicknameDuplicateException,
+  NotFirstLoginException,
   NotRefreshTokenException,
 } from './exceptions/auth.exception';
 import * as process from 'process';
@@ -138,7 +139,7 @@ export class AuthService {
         provider: 'apple',
       };
     } else {
-      return this.loginUser(user.profile.publicId);
+      throw new NotFirstLoginException(this.loginUser(user.profile.publicId));
     }
   }
 }

--- a/BackEnd/src/auth/exceptions/auth.exception.ts
+++ b/BackEnd/src/auth/exceptions/auth.exception.ts
@@ -1,5 +1,5 @@
 //auth와 관련된 exception을 모아둔 파일
-import { HttpException } from '@nestjs/common';
+import { HttpException, HttpStatus } from '@nestjs/common';
 
 export class NicknameDuplicateException extends HttpException {
   constructor() {
@@ -58,5 +58,12 @@ export class VerificationFailedIdentityToken extends HttpException {
     const response = { statusCode: 1020, message: 'apple login error.' };
     const httpCode = 400;
     super(response, httpCode);
+  }
+}
+
+export class NotFirstLoginException extends HttpException {
+  constructor(data) {
+    const response = { statusCode: null, message: null, data };
+    super(response, HttpStatus.OK);
   }
 }

--- a/BackEnd/src/common/exceptionFilters/httpException.filter.ts
+++ b/BackEnd/src/common/exceptionFilters/httpException.filter.ts
@@ -3,6 +3,7 @@ import {
   Catch,
   ExceptionFilter,
   HttpException,
+  HttpStatus,
 } from '@nestjs/common';
 
 @Catch(HttpException)
@@ -13,13 +14,16 @@ export class HttpExceptionFilter implements ExceptionFilter {
     const status = exception.getStatus();
     const exceptionResponse = exception.getResponse();
 
-    const errorMessage = exceptionResponse['message'];
-    const statusCode = exceptionResponse['statusCode'];
-
+    let errorMessage = exceptionResponse['message'];
+    let statusCode = exceptionResponse['statusCode'];
+    let data = null;
+    if(status === HttpStatus.OK) {
+      data = exceptionResponse['data'];
+    }
     response.status(status).json({
       code: statusCode,
       errorMessage,
-      data: null,
+      data,
     });
   }
 }


### PR DESCRIPTION
## 고민, 과정, 근거 💬
- 첫 로그인시 http code 201
- 첫 로그인이 아니라면 http code 200 -> access token, refresh token 발급

@POST() 응답은 무조건 http code가 201이다. 
그래서 data에 따라서 http code를 변경하기 위해서 @Res()를 사용했는데 
이 방법은 global interceptor를 무시한다.

그래서 global exception filter에 걸리게 
예외 처리로 해줬다.

첫 로그인이 아니라면 throw new NotFirstLoginException(data); 코드를 실행했고
exception filter에서는 status가 200이라면 응답 값에 data 부분이 null이 아닌 data를 넣어주는 식으로 구현했다.


---

- Closed: #336
