### PR TITLE
[GWL-351] 프로필 API 변경에 따른 코드 수정 + 로그아웃 기능 추가

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/CommonScene/Coordinator/AppCoordinator.swift
+++ b/iOS/Projects/App/WeTri/Sources/CommonScene/Coordinator/AppCoordinator.swift
@@ -76,7 +76,7 @@ final class AppCoordinator: AppCoordinating {
 
   func showTabBarFlow() {
     navigationController.isNavigationBarHidden = true
-    let tabBarCoordinator = TabBarCoordinator(navigationController: navigationController)
+    let tabBarCoordinator = TabBarCoordinator(navigationController: navigationController, tabBarFinishDelegate: self)
     childCoordinators.append(tabBarCoordinator)
     tabBarCoordinator.start()
   }
@@ -128,5 +128,13 @@ extension AppCoordinator: LoginFeatureFinishDelegate {
     if token != nil {
       showTabBarFlow()
     }
+  }
+}
+
+// MARK: TabBarFinishDelegate
+
+extension AppCoordinator: TabBarFinishDelegate {
+  func moveToLogin() {
+    showLoginFlow()
   }
 }

--- a/iOS/Projects/App/WeTri/Sources/TabBarScene/Coordinator/TabBarCoordinator.swift
+++ b/iOS/Projects/App/WeTri/Sources/TabBarScene/Coordinator/TabBarCoordinator.swift
@@ -12,20 +12,29 @@ import ProfileFeature
 import RecordFeature
 import UIKit
 
+// MARK: - TabBarFinishDelegate
+
+protocol TabBarFinishDelegate: AnyObject {
+  func moveToLogin()
+}
+
 // MARK: - TabBarCoordinator
 
 final class TabBarCoordinator: TabBarCoordinating {
   var navigationController: UINavigationController
   var childCoordinators: [Coordinating] = []
   weak var finishDelegate: CoordinatorFinishDelegate?
+  private weak var tabBarFinishDelegate: TabBarFinishDelegate?
   var flow: CoordinatorFlow = .tabBar
   var tabBarController: UITabBarController
 
   init(
     navigationController: UINavigationController,
+    tabBarFinishDelegate: TabBarFinishDelegate,
     tabBarController: UITabBarController = UITabBarController()
   ) {
     self.navigationController = navigationController
+    self.tabBarFinishDelegate = tabBarFinishDelegate
     self.tabBarController = tabBarController
   }
 
@@ -63,7 +72,11 @@ final class TabBarCoordinator: TabBarCoordinating {
       recordCoordinator.start()
 
     case .profile:
-      let profileCoordinator = ProfileCoordinator(navigationController: pageNavigationViewController, isMockEnvironment: false)
+      let profileCoordinator = ProfileCoordinator(
+        navigationController: pageNavigationViewController,
+        profileFinishDelegate: self,
+        isMockEnvironment: false
+      )
       childCoordinators.append(profileCoordinator)
       profileCoordinator.finishDelegate = self
       profileCoordinator.start()
@@ -85,6 +98,15 @@ extension TabBarCoordinator: CoordinatorFinishDelegate {
     childCoordinators = childCoordinators.filter {
       return $0.flow != childCoordinator.flow
     }
+  }
+}
+
+// MARK: ProfileFinishFinishDelegate
+
+extension TabBarCoordinator: ProfileFinishFinishDelegate {
+  func moveToLogin() {
+    finish()
+    tabBarFinishDelegate?.moveToLogin()
   }
 }
 

--- a/iOS/Projects/Features/Profile/Project.swift
+++ b/iOS/Projects/Features/Profile/Project.swift
@@ -7,7 +7,7 @@ let project = Project.makeModule(
   targets: .feature(
     .profile,
     testingOptions: [.unitTest],
-    dependencies: [.designSystem, .trinet, .combineExtension, .combineCocoa, .log, .coordinator, .commonNetworkingKeyManager],
+    dependencies: [.designSystem, .trinet, .combineExtension, .combineCocoa, .log, .coordinator, .commonNetworkingKeyManager, .keychain],
     testDependencies: [],
     resources: "Resources/**"
   )

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsRequestDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsRequestDTO.swift
@@ -26,6 +26,13 @@ public struct PostsRequestDTO: Encodable {
 
   /// 가져올 아이템 수를 의미합니다.
   let limit: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case idLessThan = "where__id__less_then"
+    case idMoreThan = "where__id__more_then"
+    case orderCreatedAt = "order__createdAt"
+    case limit = "take"
+  }
 }
 
 // MARK: - Order

--- a/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/DTO/PostsResponseDTO.swift
@@ -49,7 +49,7 @@ struct PagingMetaData: Codable {
   /// 받아온 데이터 중 제일 마지막의 ID값
   ///
   /// 다음에 요청으로 보낼 id값입니다.
-  let lastID: Int
+  let lastID: Int?
 
   /// 받아온 데이터 개수
   let count: Int

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/KeychainRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/KeychainRepository.swift
@@ -1,0 +1,61 @@
+//
+//  KeychainRepository.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import Foundation
+import Keychain
+import Log
+
+// MARK: - KeychainRepositoryError
+
+enum KeychainRepositoryError: Error {
+  case invalidKey
+  case invalidValue
+}
+
+// MARK: - KeychainRepository
+
+final class KeychainRepository: KeychainRepositoryRepresentable {
+  private let keychain: Keychaining
+
+  init(keychain: Keychaining) {
+    self.keychain = keychain
+  }
+
+  func save(key: String, value: String) {
+    do {
+      guard let data = value.data(using: .utf8) else {
+        throw KeychainRepositoryError.invalidValue
+      }
+      keychain.save(key: key, data: data)
+    } catch {
+      Log.make().error("\(error)")
+    }
+  }
+
+  func load(key: String) -> AnyPublisher<Data, Error> {
+    return Future<Data, Error> { [weak self] promise in
+      guard let data = self?.keychain.load(key: key) else {
+        return promise(.failure(KeychainRepositoryError.invalidKey))
+      }
+      return promise(.success(data))
+    }
+    .eraseToAnyPublisher()
+  }
+
+  func delete(key: String) -> AnyPublisher<Void, Error> {
+    return Future<Void, Error> { [weak self] promise in
+      let status = self?.keychain.delete(key: key)
+      guard status != errSecItemNotFound else {
+        return promise(.failure(KeychainRepositoryError.invalidKey))
+      }
+      return promise(.success(()))
+    }
+    .eraseToAnyPublisher()
+  }
+}

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileRepository.swift
@@ -91,9 +91,9 @@ extension ProfileEndPoint: TNEndPoint {
   var path: String {
     switch self {
     case .fetchProfile:
-      return "/api/v1/profiles"
+      return "/api/v1/profiles/me"
     case .fetchPosts:
-      return "/api/v1/posts"
+      return "/api/v1/profiles/me/posts"
     }
   }
 

--- a/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/KeychainRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/KeychainRepositoryRepresentable.swift
@@ -1,0 +1,21 @@
+//
+//  KeychainRepositoryRepresentable.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+public protocol KeychainRepositoryRepresentable {
+  /// 키체인에 키-data로 데이터를 저장합니다.
+  func save(key: String, value: String)
+
+  /// 키체인에서 키를 통해 data 값을 얻어옵니다.
+  func load(key: String) -> AnyPublisher<Data, Error>
+
+  /// 키체인에서 해당하는 키를 삭제합니다.
+  func delete(key: String) -> AnyPublisher<Void, Error>
+}

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/LogoutUseCase.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/LogoutUseCase.swift
@@ -1,0 +1,32 @@
+//
+//  LogoutUseCase.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import CommonNetworkingKeyManager
+import Foundation
+import Log
+
+// MARK: - AuthorizeUseCase
+
+final class LogoutUseCase: LogoutUseCaseRepresentable {
+  private let keychainRepository: KeychainRepositoryRepresentable
+
+  init(
+    keychainRepository: KeychainRepositoryRepresentable
+  ) {
+    self.keychainRepository = keychainRepository
+  }
+
+  func logout() -> AnyPublisher<Bool, Never> {
+    keychainRepository.delete(key: Tokens.accessToken)
+      .combineLatest(keychainRepository.delete(key: Tokens.refreshToken))
+      .map { _ in true } // 삭제 성공 시 true
+      .catch { _ in Just(false) } // 실패 시 false
+      .eraseToAnyPublisher()
+  }
+}

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/LogoutUseCaseRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/LogoutUseCaseRepresentable.swift
@@ -1,0 +1,13 @@
+//
+//  LogoutUseCaseRepresentable.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+
+protocol LogoutUseCaseRepresentable {
+  func logout() -> AnyPublisher<Bool, Never>
+}

--- a/iOS/Projects/Features/Profile/Sources/Presentation/Coordinator/ProfileCoordinator.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/Coordinator/ProfileCoordinator.swift
@@ -12,20 +12,29 @@ import Log
 import Trinet
 import UIKit
 
+// MARK: - ProfileFinishFinishDelegate
+
+public protocol ProfileFinishFinishDelegate: AnyObject {
+  func moveToLogin()
+}
+
 // MARK: - ProfileCoordinator
 
 public final class ProfileCoordinator {
   public var navigationController: UINavigationController
   public var childCoordinators: [Coordinating] = []
   public weak var finishDelegate: CoordinatorFinishDelegate?
+  private weak var profileFinishDelegate: ProfileFinishFinishDelegate?
   public var flow: CoordinatorFlow = .profile
   private let isMockEnvironment: Bool
 
   public init(
     navigationController: UINavigationController,
+    profileFinishDelegate: ProfileFinishFinishDelegate,
     isMockEnvironment: Bool = false
   ) {
     self.navigationController = navigationController
+    self.profileFinishDelegate = profileFinishDelegate
     self.isMockEnvironment = isMockEnvironment
   }
 
@@ -59,7 +68,10 @@ public final class ProfileCoordinator {
 // MARK: ProfileCoordinating
 
 extension ProfileCoordinator: ProfileCoordinating {
-  public func moveToLogin() {}
+  public func moveToLogin() {
+    finish()
+    profileFinishDelegate?.moveToLogin()
+  }
 
   public func moveToProfileSettings() {
     let viewModel = ProfileSettingsViewModel(coordinating: self)

--- a/iOS/Projects/Features/Profile/Sources/Presentation/Coordinator/ProfileCoordinator.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/Coordinator/ProfileCoordinator.swift
@@ -7,6 +7,7 @@
 //
 
 import Coordinator
+import Keychain
 import Log
 import Trinet
 import UIKit
@@ -68,7 +69,9 @@ extension ProfileCoordinator: ProfileCoordinating {
   }
 
   public func pushToSettings() {
-    let viewModel = SettingsViewModel(coordinating: self)
+    let repository = KeychainRepository(keychain: Keychain.shared)
+    let useCase = LogoutUseCase(keychainRepository: repository)
+    let viewModel = SettingsViewModel(coordinating: self, useCase: useCase)
     let viewController = SettingsViewController(viewModel: viewModel)
     viewController.hidesBottomBarWhenPushed = true
     navigationController.pushViewController(viewController, animated: true)

--- a/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewController.swift
@@ -70,13 +70,24 @@ final class SettingsViewController: UICollectionViewController {
         logoutPublisher: logoutSubject.eraseToAnyPublisher()
       )
     )
-    .sink { state in
+    .sink { [weak self] state in
       switch state {
       case .idle:
         break
+      case let .alert(message):
+        self?.showAlert(with: message)
       }
     }
     .store(in: &subscriptions)
+  }
+
+  // MARK: - Custom Methods
+
+  /// 에러 알림 문구를 보여줍니다.
+  private func showAlert(with value: Any) {
+    let alertController = UIAlertController(title: "알림", message: String(describing: value), preferredStyle: .alert)
+    alertController.addAction(UIAlertAction(title: "확인", style: .default))
+    present(alertController, animated: true)
   }
 }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewController.swift
@@ -144,7 +144,14 @@ extension SettingsViewController {
     case .profileSetting:
       profileSettings.send(())
     case .logout:
-      logoutSubject.send(())
+      let alertController = UIAlertController(title: "알림", message: "정말 로그아웃 하시겠습니까?", preferredStyle: .alert)
+      let okAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
+        self?.logoutSubject.send(())
+      }
+      let cancelAction = UIAlertAction(title: "취소", style: .cancel)
+      alertController.addAction(okAction)
+      alertController.addAction(cancelAction)
+      present(alertController, animated: true)
     default:
       break
     }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewController.swift
@@ -19,6 +19,7 @@ final class SettingsViewController: UICollectionViewController {
   private let viewModel: SettingsViewModelRepresentable
 
   private let profileSettings: PassthroughSubject<Void, Never> = .init()
+  private let logoutSubject: PassthroughSubject<Void, Never> = .init()
 
   private var dataSource: SettingsDataSource?
 
@@ -63,8 +64,13 @@ final class SettingsViewController: UICollectionViewController {
   }
 
   private func bind() {
-    let output = viewModel.transform(input: .init(profileSettingsPublisher: profileSettings.eraseToAnyPublisher()))
-    output.sink { state in
+    viewModel.transform(
+      input: .init(
+        profileSettingsPublisher: profileSettings.eraseToAnyPublisher(),
+        logoutPublisher: logoutSubject.eraseToAnyPublisher()
+      )
+    )
+    .sink { state in
       switch state {
       case .idle:
         break
@@ -123,8 +129,13 @@ extension SettingsViewController {
       return
     }
 
-    if Item.allCases[indexPath.item] == .profileSetting {
+    switch Item.allCases[indexPath.item] {
+    case .profileSetting:
       profileSettings.send(())
+    case .logout:
+      logoutSubject.send(())
+    default:
+      break
     }
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewModel.swift
@@ -37,14 +37,17 @@ final class SettingsViewModel {
   // MARK: - Properties
 
   private weak var coordinating: ProfileCoordinating?
+  private let useCase: LogoutUseCaseRepresentable
+
   private var subscriptions: Set<AnyCancellable> = []
+
+  init(coordinating: ProfileCoordinating?, useCase: LogoutUseCaseRepresentable) {
+    self.coordinating = coordinating
+    self.useCase = useCase
+  }
 
   deinit {
     Log.make().debug("\(Self.self) deinitialized")
-  }
-
-  init(coordinating: ProfileCoordinating?) {
-    self.coordinating = coordinating
   }
 }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewModel.swift
@@ -14,6 +14,7 @@ import Log
 
 public struct SettingsViewModelInput {
   let profileSettingsPublisher: AnyPublisher<Void, Never>
+  let logoutPublisher: AnyPublisher<Void, Never>
 }
 
 public typealias SettingsViewModelOutput = AnyPublisher<SettingsState, Never>

--- a/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/SettingsScene/SettingsViewModel.swift
@@ -65,6 +65,13 @@ extension SettingsViewModel: SettingsViewModelRepresentable {
       .flatMap(useCase.logout)
       .share()
 
+    logoutPublisher
+      .filter { $0 == true }
+      .sink { [coordinating] _ in
+        coordinating?.moveToLogin()
+      }
+      .store(in: &subscriptions)
+
     let alertPublisher = logoutPublisher
       .filter { $0 == false }
       .map { _ in SettingsState.alert("로그아웃할 수 없습니다.") }


### PR DESCRIPTION
## Screenshots 📸

|로그아웃 기능 화면|
|:-:|
|![RPReplay_Final1702227357](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/10c669e3-5d3b-41be-8082-cb8b6bad074c)|

## 고민, 과정, 근거 💬

- 프로필 API가 변경되어 서버에 맞게 수정했습니다.
- 로그아웃 버튼이 눌리면 로그아웃 화면으로 넘어가도록 구현했습니다.

---

- Closed: #351
