### PR TITLE
[GWL-353] 프로필 설정 화면 시 사용자 정보 데이터 파싱

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/TabBarScene/Coordinator/TabBarCoordinator.swift
+++ b/iOS/Projects/App/WeTri/Sources/TabBarScene/Coordinator/TabBarCoordinator.swift
@@ -7,6 +7,7 @@
 //
 
 import Coordinator
+import DesignSystem
 import HomeFeature
 import ProfileFeature
 import RecordFeature
@@ -30,10 +31,11 @@ final class TabBarCoordinator: TabBarCoordinating {
   }
 
   func start() {
-    let tabBarViewControllers = TabBarPage.allCases.map {
+    let tabBarViewControllers = [TabBarPage.record, TabBarPage.profile].map {
       return makePageNavigationController(page: $0)
     }
     let tabBarController = makeTabBarController(tabBarViewControllers: tabBarViewControllers)
+    UITabBar.appearance().tintColor = DesignSystemColor.main03
     navigationController.pushViewController(tabBarController, animated: true)
   }
 
@@ -47,12 +49,6 @@ final class TabBarCoordinator: TabBarCoordinating {
 
   private func startTabBarCoordinator(page: TabBarPage, pageNavigationViewController: UINavigationController) {
     switch page {
-    case .home:
-      let homeCoordinator = HomeCoordinator(navigationController: pageNavigationViewController, delegate: self)
-      childCoordinators.append(homeCoordinator)
-      homeCoordinator.finishDelegate = self
-      homeCoordinator.start()
-
     case .record:
       let recordCoordinator = RecordFeatureCoordinator(
         navigationController: pageNavigationViewController,
@@ -67,6 +63,8 @@ final class TabBarCoordinator: TabBarCoordinating {
       childCoordinators.append(profileCoordinator)
       profileCoordinator.finishDelegate = self
       profileCoordinator.start()
+    default:
+      break
     }
   }
 
@@ -113,7 +111,7 @@ private extension TabBarPage {
     case .home:
       return UIImage(systemName: "house")
     case .record:
-      return UIImage(systemName: "star")
+      return UIImage(systemName: "figure.run")
     case .profile:
       return UIImage(systemName: "person")
     }
@@ -124,7 +122,7 @@ private extension TabBarPage {
     case .home:
       return UIImage(systemName: "house.fill")
     case .record:
-      return UIImage(systemName: "star.fill")
+      return UIImage(systemName: "figure.run")
     case .profile:
       return UIImage(systemName: "person.fill")
     }

--- a/iOS/Projects/Features/Profile/Project.swift
+++ b/iOS/Projects/Features/Profile/Project.swift
@@ -7,7 +7,16 @@ let project = Project.makeModule(
   targets: .feature(
     .profile,
     testingOptions: [.unitTest],
-    dependencies: [.designSystem, .trinet, .combineExtension, .combineCocoa, .log, .coordinator, .commonNetworkingKeyManager],
+    dependencies: [
+      .designSystem,
+      .trinet,
+      .combineExtension,
+      .combineCocoa,
+      .log,
+      .coordinator,
+      .commonNetworkingKeyManager,
+      .userInformationManager
+    ],
     testDependencies: [],
     resources: "Resources/**"
   )

--- a/iOS/Projects/Features/Profile/Project.swift
+++ b/iOS/Projects/Features/Profile/Project.swift
@@ -15,7 +15,7 @@ let project = Project.makeModule(
       .log,
       .coordinator,
       .commonNetworkingKeyManager,
-      .userInformationManager
+      .userInformationManager,
     ],
     testDependencies: [],
     resources: "Resources/**"

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileSettingsRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileSettingsRepository.swift
@@ -9,10 +9,31 @@
 import Foundation
 import UserInformationManager
 
+// MARK: - ProfileSettingsRepository
+
 struct ProfileSettingsRepository: ProfileSettingsRepositoryRepresentable {
   private let persistency: UserInformationManager
 
   init(persistency: UserInformationManager) {
     self.persistency = persistency
   }
+
+  func userInformation() throws -> Profile {
+    guard
+      let profileImageData = persistency.data(.userProfileImage),
+      let nicknameData = persistency.data(.userNickName),
+      let birthData = persistency.data(.birthDayDate),
+      let nickname = String(data: nicknameData, encoding: .utf8),
+      let birth = String(data: birthData, encoding: .utf8)
+    else {
+      throw ProfileSettingsRepositoryError.retrievalError
+    }
+    return .init(profileData: profileImageData, nickname: nickname, birth: birth)
+  }
+}
+
+// MARK: - ProfileSettingsRepositoryError
+
+private enum ProfileSettingsRepositoryError: Error {
+  case retrievalError
 }

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileSettingsRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileSettingsRepository.swift
@@ -34,6 +34,13 @@ struct ProfileSettingsRepository: ProfileSettingsRepositoryRepresentable {
 
 // MARK: - ProfileSettingsRepositoryError
 
-private enum ProfileSettingsRepositoryError: Error {
+private enum ProfileSettingsRepositoryError: LocalizedError {
   case retrievalError
+
+  var errorDescription: String? {
+    switch self {
+    case .retrievalError:
+      return "프로필 데이터를 찾을 수 없습니다."
+    }
+  }
 }

--- a/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileSettingsRepository.swift
+++ b/iOS/Projects/Features/Profile/Sources/Data/Repositories/ProfileSettingsRepository.swift
@@ -1,0 +1,18 @@
+//
+//  ProfileSettingsRepository.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+import UserInformationManager
+
+struct ProfileSettingsRepository: ProfileSettingsRepositoryRepresentable {
+  private let persistency: UserInformationManager
+
+  init(persistency: UserInformationManager) {
+    self.persistency = persistency
+  }
+}

--- a/iOS/Projects/Features/Profile/Sources/Domain/Entities/Profile.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/Entities/Profile.swift
@@ -14,4 +14,13 @@ public struct Profile {
 
   /// 프로필 닉네임
   let nickname: String
+
+  /// 사용자의 생년월일
+  let birth: String?
+
+  init(profileData: Data, nickname: String, birth: String? = nil) {
+    self.profileData = profileData
+    self.nickname = nickname
+    self.birth = birth
+  }
 }

--- a/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileSettingsRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileSettingsRepositoryRepresentable.swift
@@ -8,4 +8,6 @@
 
 import Foundation
 
-protocol ProfileSettingsRepositoryRepresentable {}
+protocol ProfileSettingsRepositoryRepresentable {
+  func userInformation() throws -> Profile
+}

--- a/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileSettingsRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/Interfaces/ProfileSettingsRepositoryRepresentable.swift
@@ -1,0 +1,11 @@
+//
+//  ProfileSettingsRepositoryRepresentable.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+protocol ProfileSettingsRepositoryRepresentable {}

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileSettingsUseCase.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileSettingsUseCase.swift
@@ -14,4 +14,8 @@ struct ProfileSettingsUseCase: ProfileSettingsUseCaseRepresentable {
   init(repository: ProfileSettingsRepositoryRepresentable) {
     self.repository = repository
   }
+
+  func userInformation() throws -> Profile {
+    return try repository.userInformation()
+  }
 }

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileSettingsUseCase.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/ProfileSettingsUseCase.swift
@@ -1,0 +1,17 @@
+//
+//  ProfileSettingsUseCase.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+struct ProfileSettingsUseCase: ProfileSettingsUseCaseRepresentable {
+  private let repository: ProfileSettingsRepositoryRepresentable
+
+  init(repository: ProfileSettingsRepositoryRepresentable) {
+    self.repository = repository
+  }
+}

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileSettingsUseCaseRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileSettingsUseCaseRepresentable.swift
@@ -8,4 +8,6 @@
 
 import Foundation
 
-protocol ProfileSettingsUseCaseRepresentable {}
+protocol ProfileSettingsUseCaseRepresentable {
+  func userInformation() throws -> Profile
+}

--- a/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileSettingsUseCaseRepresentable.swift
+++ b/iOS/Projects/Features/Profile/Sources/Domain/UseCases/Protocol/ProfileSettingsUseCaseRepresentable.swift
@@ -1,0 +1,11 @@
+//
+//  ProfileSettingsUseCaseRepresentable.swift
+//  ProfileFeature
+//
+//  Created by 홍승현 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+protocol ProfileSettingsUseCaseRepresentable {}

--- a/iOS/Projects/Features/Profile/Sources/Presentation/Coordinator/ProfileCoordinator.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/Coordinator/ProfileCoordinator.swift
@@ -61,7 +61,9 @@ extension ProfileCoordinator: ProfileCoordinating {
   public func moveToLogin() {}
 
   public func moveToProfileSettings() {
-    let viewModel = ProfileSettingsViewModel(coordinating: self)
+    let repository = ProfileSettingsRepository(persistency: .shared)
+    let useCase = ProfileSettingsUseCase(repository: repository)
+    let viewModel = ProfileSettingsViewModel(coordinating: self, useCase: useCase)
     let viewController = ProfileSettingsViewController(viewModel: viewModel)
     viewController.hidesBottomBarWhenPushed = true
     navigationController.pushViewController(viewController, animated: true)

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsHeaderView.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsHeaderView.swift
@@ -85,10 +85,12 @@ final class ProfileSettingsHeaderView: UICollectionReusableView {
     )
   }
 
-  func configure(with model: Profile) {
-    imageView.image = UIImage(data: model.profileData)
-    nicknameLabel.text = model.nickname
-    birthLabel.text = model.birth
+  func configure(with model: Profile?) {
+    if let model {
+      imageView.image = UIImage(data: model.profileData)
+      nicknameLabel.text = model.nickname
+      birthLabel.text = model.birth
+    }
   }
 }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsHeaderView.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsHeaderView.swift
@@ -84,6 +84,12 @@ final class ProfileSettingsHeaderView: UICollectionReusableView {
       ]
     )
   }
+
+  func configure(with model: Profile) {
+    imageView.image = UIImage(data: model.profileData)
+    nicknameLabel.text = model.nickname
+    birthLabel.text = model.birth
+  }
 }
 
 // MARK: ProfileSettingsHeaderView.Metrics

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
@@ -33,7 +33,9 @@ final class ProfileSettingsViewController: UICollectionViewController {
     let layout = UICollectionViewCompositionalLayout { sectionNumber, environment in
       // Section을 위한 리스트 configuration 생성
       var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
-      configuration.headerMode = .supplementary
+      if sectionNumber == Section.header.rawValue {
+        configuration.headerMode = .supplementary
+      }
 
       // Header를 위한 Supplementary Item 등록
       let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(44))
@@ -136,7 +138,8 @@ private extension ProfileSettingsViewController {
       cell.contentConfiguration = configuration
     }
 
-    let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { _, _, _ in
+    let headerRegistration = HeaderRegistration(elementKind: UICollectionView.elementKindSectionHeader) { [weak self] headerView, _, _ in
+      headerView.configure(with: self?.headerViewData)
     }
 
     let dataSource = ProfileSettingsDataSource(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
@@ -164,6 +167,9 @@ private extension ProfileSettingsViewController {
 
   private func updateProfileHeaders() {
     guard let dataSource else { return }
+
+    var snapshot = dataSource.snapshot()
+    snapshot.reloadSections([.header])
   }
 }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
@@ -23,6 +23,8 @@ final class ProfileSettingsViewController: UICollectionViewController {
 
   private var dataSource: ProfileSettingsDataSource?
 
+  private var headerViewData: Profile?
+
   // MARK: Initializations
 
   init(viewModel: ProfileSettingsViewModelRepresentable) {
@@ -89,7 +91,8 @@ final class ProfileSettingsViewController: UICollectionViewController {
     case let .alert(error):
       showAlert(message: error.localizedDescription)
     case let .profile(profile):
-      break
+      headerViewData = profile
+      updateProfileHeaders()
     }
   }
 
@@ -154,6 +157,10 @@ private extension ProfileSettingsViewController {
     snapshot.appendSections([.main])
     snapshot.appendItems(Item.allCases, toSection: .main)
     dataSource.apply(snapshot, animatingDifferences: false)
+  }
+
+  private func updateProfileHeaders() {
+    guard let dataSource else { return }
   }
 }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
@@ -169,6 +169,7 @@ private extension ProfileSettingsViewController {
     guard let dataSource else { return }
 
     var snapshot = dataSource.snapshot()
+
     snapshot.reloadSections([.header])
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
@@ -87,10 +87,24 @@ final class ProfileSettingsViewController: UICollectionViewController {
     case .idle:
       break
     case let .alert(error):
-      break
+      showAlert(message: error.localizedDescription)
     case let .profile(profile):
       break
     }
+  }
+
+  private func showAlert(
+    title: String = "알림",
+    message: String,
+    showCancel: Bool = false,
+    okActionHandler: ((UIAlertAction) -> Void)? = nil
+  ) {
+    let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+    alertController.addAction(.init(title: "확인", style: .default, handler: okActionHandler))
+    if showCancel {
+      alertController.addAction(.init(title: "취소", style: .cancel))
+    }
+    present(alertController, animated: true)
   }
 }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
@@ -15,6 +15,8 @@ import UIKit
 final class ProfileSettingsViewController: UICollectionViewController {
   // MARK: Properties
 
+  private let viewDidLoadSubject: PassthroughSubject<Void, Never> = .init()
+
   private let viewModel: ProfileSettingsViewModelRepresentable
 
   private var subscriptions: Set<AnyCancellable> = []
@@ -62,6 +64,7 @@ final class ProfileSettingsViewController: UICollectionViewController {
     bind()
     setupDataSource()
     setupInitialSnapshots()
+    viewDidLoadSubject.send(())
   }
 
   // MARK: Configuration
@@ -72,14 +75,22 @@ final class ProfileSettingsViewController: UICollectionViewController {
   }
 
   private func bind() {
-    let output = viewModel.transform(input: .init())
-    output.sink { state in
-      switch state {
-      case .idle:
-        break
+    viewModel.transform(input: .init(viewDidLoad: viewDidLoadSubject.eraseToAnyPublisher()))
+      .sink { [weak self] state in
+        self?.render(state: state)
       }
+      .store(in: &subscriptions)
+  }
+
+  private func render(state: ProfileSettingsState) {
+    switch state {
+    case .idle:
+      break
+    case let .alert(error):
+      break
+    case let .profile(profile):
+      break
     }
-    .store(in: &subscriptions)
   }
 }
 

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
@@ -30,7 +30,7 @@ final class ProfileSettingsViewController: UICollectionViewController {
   init(viewModel: ProfileSettingsViewModelRepresentable) {
     self.viewModel = viewModel
 
-    let layout = UICollectionViewCompositionalLayout { _, environment in
+    let layout = UICollectionViewCompositionalLayout { sectionNumber, environment in
       // Section을 위한 리스트 configuration 생성
       var configuration = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
       configuration.headerMode = .supplementary
@@ -45,7 +45,9 @@ final class ProfileSettingsViewController: UICollectionViewController {
 
       // Section에 header 추가
       let section = NSCollectionLayoutSection.list(using: configuration, layoutEnvironment: environment)
-      section.boundarySupplementaryItems = [header]
+      if sectionNumber == Section.header.rawValue {
+        section.boundarySupplementaryItems = [header]
+      }
 
       return section
     }
@@ -117,7 +119,8 @@ private extension ProfileSettingsViewController {
   typealias ListCellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, Item>
   typealias HeaderRegistration = UICollectionView.SupplementaryRegistration<ProfileSettingsHeaderView>
 
-  enum Section {
+  enum Section: Int {
+    case header
     case main
   }
 
@@ -154,7 +157,7 @@ private extension ProfileSettingsViewController {
   private func setupInitialSnapshots() {
     guard let dataSource else { return }
     var snapshot = ProfileSettingsSnapshot()
-    snapshot.appendSections([.main])
+    snapshot.appendSections([.header, .main])
     snapshot.appendItems(Item.allCases, toSection: .main)
     dataSource.apply(snapshot, animatingDifferences: false)
   }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewController.swift
@@ -176,5 +176,6 @@ private extension ProfileSettingsViewController {
 extension ProfileSettingsViewController {
   override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
     collectionView.deselectItem(at: indexPath, animated: true)
+    showAlert(message: "준비중입니다.")
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewModel.swift
@@ -11,7 +11,9 @@ import Foundation
 
 // MARK: - ProfileSettingsViewModelInput
 
-public struct ProfileSettingsViewModelInput {}
+public struct ProfileSettingsViewModelInput {
+  let viewDidLoad: AnyPublisher<Void, Never>
+}
 
 public typealias ProfileSettingsViewModelOutput = AnyPublisher<ProfileSettingsState, Never>
 
@@ -19,6 +21,8 @@ public typealias ProfileSettingsViewModelOutput = AnyPublisher<ProfileSettingsSt
 
 public enum ProfileSettingsState {
   case idle
+  case alert(Error)
+  case profile(Profile)
 }
 
 // MARK: - ProfileSettingsViewModelRepresentable
@@ -46,11 +50,14 @@ final class ProfileSettingsViewModel {
 // MARK: ProfileSettingsViewModelRepresentable
 
 extension ProfileSettingsViewModel: ProfileSettingsViewModelRepresentable {
-  public func transform(input _: ProfileSettingsViewModelInput) -> ProfileSettingsViewModelOutput {
+  public func transform(input: ProfileSettingsViewModelInput) -> ProfileSettingsViewModelOutput {
     subscriptions.removeAll()
 
-    let initialState: ProfileSettingsViewModelOutput = Just(.idle).eraseToAnyPublisher()
+    let profilePublisher = input.viewDidLoad
+      .tryMap(useCase.userInformation)
+      .map(ProfileSettingsState.profile)
+      .catch { Just(.alert($0)) }
 
-    return initialState
+    return Just(.idle).merge(with: profilePublisher).eraseToAnyPublisher()
   }
 }

--- a/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewModel.swift
+++ b/iOS/Projects/Features/Profile/Sources/Presentation/ProfileSettingsScene/ProfileSettingsViewModel.swift
@@ -33,11 +33,13 @@ final class ProfileSettingsViewModel {
   // MARK: - Properties
 
   private weak var coordinating: ProfileCoordinating?
+  private let useCase: ProfileSettingsUseCase
 
   private var subscriptions: Set<AnyCancellable> = []
 
-  init(coordinating: ProfileCoordinating? = nil) {
+  init(coordinating: ProfileCoordinating?, useCase: ProfileSettingsUseCase) {
     self.coordinating = coordinating
+    self.useCase = useCase
   }
 }
 


### PR DESCRIPTION
## Screenshots 📸

|Name|
|:-:|
|![RPReplay_Final1702256213](https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/3474be79-4e0c-433a-9d8f-9db5b0b35d1d)|

<br/><br/>

## 고민, 과정, 근거 💬

프로필 설정 화면이 기본값으로 설정되는 것을 수정했습니다. UserDefaults로 사용자의 데이터 정보를 가져와 뿌려줍니다.

---

- Closed: #353
