### PR TITLE
[GWL-362] 앨범에서 이미지 선택 시, 이미지피커가 사라지지 않는 문제 개선

### DIFF
--- a/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
@@ -394,8 +394,8 @@ extension SignUpProfileViewController: UIImagePickerControllerDelegate {
           return
         }
         imageSetSubject.send(downsampledData)
-        dismiss(animated: true)
       }
+      dismiss(animated: true)
     } catch {
       Log.make().error("\(error)")
       profileImageButton.image = UIImage(systemName: "person.fill")


### PR DESCRIPTION
## Screenshots 📸
❌

<br/><br/>

## 고민, 과정, 근거 💬
- 선택하자마자 사라지지 않았던 이유는 선택 시, dismiss를 카메라부분 로직에만 적용해서 그랬습니다. 🥲

- 확인버튼을 추가하기위해 알아보고 코드를 작성하던 도중, 문득 앨범에서 선택하면 사라지지 않는 현상때문에 해당 트러블에 대한 피드백을 받았다는 생각이 들었습니다. 그래서 확인해보니 앨범에서 사진을 선택하면 피커가 사라지지 않았고 해당현상을 개선하였습니다.

<br/><br/>

## References 📋
❌

<br/><br/>

---

- Closed: #362 
