### PR TITLE
[GWL-375] 운동 기록 리스트 fetching 안되는 버그 수정

### DIFF
--- a/iOS/Projects/Features/Record/Resources/Persistency/Records.json
+++ b/iOS/Projects/Features/Record/Resources/Persistency/Records.json
@@ -3,54 +3,100 @@
   "errorMessage": null,
   "data": [
     {
-      "workoutTime": 60000,
-      "distance": 100000,
-      "calorie": 360,
-      "avgHeartRate": 60,
-      "minHeartRate": 120,
-      "maxHeartRate": 180,
-      "createdAt": "2023-11-22 09:00:00",
-      "workout": "달리기"
+      "id": 170,
+      "workoutTime": 4,
+      "distance": 125,
+      "calorie": 1,
+      "avgHeartRate": 0,
+      "minHeartRate": 0,
+      "maxHeartRate": 0,
+      "createdAt": "2023-12-11T20:07:48.083Z",
+      "mapCapture": null,
+      "gps": "37.1235/127.3837",
+      "isPosted": false,
+      "workout": {
+        "name": "달리기"
+      }
     },
     {
-      "workoutTime": 60000,
-      "distance": 100000,
-      "calorie": 360,
-      "avgHeartRate": 60,
-      "minHeartRate": 120,
-      "maxHeartRate": 180,
-      "createdAt": "2023-11-22 09:00:00",
-      "workout": "수영"
+      "id": 171,
+      "workoutTime": 4,
+      "distance": 125,
+      "calorie": 1,
+      "avgHeartRate": 0,
+      "minHeartRate": 0,
+      "maxHeartRate": 0,
+      "createdAt": "2023-12-11T20:07:48.083Z",
+      "mapCapture": null,
+      "gps": "37.1235/127.3837",
+      "isPosted": false,
+      "workout": {
+        "name": "달리기"
+      }
     },
     {
-      "workoutTime": 60000,
-      "distance": 100000,
-      "calorie": 360,
-      "avgHeartRate": 60,
-      "minHeartRate": 120,
-      "maxHeartRate": 180,
-      "createdAt": "2023-11-22 09:00:00",
-      "workout": "자전거"
+      "id": 172,
+      "workoutTime": 4,
+      "distance": 125,
+      "calorie": 1,
+      "avgHeartRate": 0,
+      "minHeartRate": 0,
+      "maxHeartRate": 0,
+      "createdAt": "2023-12-11T20:07:48.083Z",
+      "mapCapture": null,
+      "gps": "37.1235/127.3837",
+      "isPosted": false,
+      "workout": {
+        "name": "달리기"
+      }
     },
     {
-      "workoutTime": 60000,
-      "distance": 100000,
-      "calorie": 360,
-      "avgHeartRate": 60,
-      "minHeartRate": 120,
-      "maxHeartRate": 180,
-      "createdAt": "2023-11-22 09:00:00",
-      "workout": "달리기"
+      "id": 173,
+      "workoutTime": 4,
+      "distance": 125,
+      "calorie": 1,
+      "avgHeartRate": 0,
+      "minHeartRate": 0,
+      "maxHeartRate": 0,
+      "createdAt": "2023-12-11T20:07:48.083Z",
+      "mapCapture": null,
+      "gps": "37.1235/127.3837",
+      "isPosted": false,
+      "workout": {
+        "name": "달리기"
+      }
     },
     {
-      "workoutTime": 60000,
-      "distance": 100000,
-      "calorie": 360,
-      "avgHeartRate": 60,
-      "minHeartRate": 120,
-      "maxHeartRate": 180,
-      "createdAt": "2023-11-22 09:00:00",
-      "workout": "수영"
-    }
+      "id": 174,
+      "workoutTime": 4,
+      "distance": 125,
+      "calorie": 1,
+      "avgHeartRate": 0,
+      "minHeartRate": 0,
+      "maxHeartRate": 0,
+      "createdAt": "2023-12-11T20:07:48.083Z",
+      "mapCapture": null,
+      "gps": "37.1235/127.3837",
+      "isPosted": false,
+      "workout": {
+        "name": "달리기"
+      }
+    },
+    {
+      "id": 175,
+      "workoutTime": 4,
+      "distance": 125,
+      "calorie": 1,
+      "avgHeartRate": 0,
+      "minHeartRate": 0,
+      "maxHeartRate": 0,
+      "createdAt": "2023-12-11T20:07:48.083Z",
+      "mapCapture": null,
+      "gps": "37.1235/127.3837",
+      "isPosted": false,
+      "workout": {
+        "name": "달리기"
+      }
+    },
   ]
 }

--- a/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
+++ b/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
@@ -17,7 +17,7 @@ struct RecordResponseDTO: Codable {
   let avgHeartRate: Int?
   let minHeartRate: Int?
   let maxHeartRate: Int?
-  let createdAt: String?
+  let createdAt: Date?
   let workout: WorkoutResponseDTO?
 }
 
@@ -44,28 +44,22 @@ extension Record {
     self.endTime = endTime
   }
 
-  private static func timeToTime(createdAt: String, workoutTime: Int) -> (startTime: String, endTime: String)? {
-    let startTime = createdAt.components(separatedBy: .whitespaces)[1]
-    guard let time = separateTime(startTime: startTime) else {
-      return nil
-    }
-    let startSeconds = time.toSeconds()
-    let endSeconds = startSeconds + workoutTime
-    let start = prettyStyle(time: timeToHourMinuteSecond(seconds: startSeconds))
-    let end = prettyStyle(time: timeToHourMinuteSecond(seconds: endSeconds))
-    return (start, end)
-  }
+  private static func timeToTime(createdAt: Date, workoutTime: Int) -> (startTime: String, endTime: String)? {
+    let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: createdAt)
 
-  private static func separateTime(startTime: String) -> Time? {
-    let hhmmss = startTime.components(separatedBy: ":")
-    guard let hour = Int(hhmmss[0]),
-          let minute = Int(hhmmss[1]),
-          let second = Int(hhmmss[2])
+    guard
+      let hour = dateComponents.hour,
+      let minute = dateComponents.minute,
+      let second = dateComponents.second
     else {
       return nil
     }
 
-    return Time(hour: hour, minute: minute, second: second)
+    let startSeconds = Time(hour: hour, minute: minute, second: second).toSeconds()
+    let endSeconds = startSeconds + workoutTime
+    let start = prettyStyle(time: timeToHourMinuteSecond(seconds: startSeconds))
+    let end = prettyStyle(time: timeToHourMinuteSecond(seconds: endSeconds))
+    return (start, end)
   }
 
   private static func timeToHourMinuteSecond(seconds: Int) -> Time {

--- a/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
+++ b/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - RecordResponseDTO
 
-struct RecordResponseDTO {
+struct RecordResponseDTO: Codable {
   let workoutTime: Int?
   let distance: Int?
   let calorie: Int?
@@ -18,16 +18,19 @@ struct RecordResponseDTO {
   let minHeartRate: Int?
   let maxHeartRate: Int?
   let createdAt: String?
-  let workout: String?
+  let workout: WorkoutResponseDTO?
 }
 
-// MARK: Codable
+// MARK: - WorkoutResponseDTO
 
-extension RecordResponseDTO: Codable {}
+struct WorkoutResponseDTO: Codable {
+  /// 운동 이름
+  let name: String?
+}
 
 extension Record {
   init?(dto: RecordResponseDTO) {
-    guard let workout = dto.workout,
+    guard let workout = dto.workout?.name,
           let distance = dto.distance,
           let createdAt = dto.createdAt,
           let workoutTime = dto.workoutTime,

--- a/iOS/Projects/Features/Record/Sources/Data/Repositories/WorkoutRecordsRepository.swift
+++ b/iOS/Projects/Features/Record/Sources/Data/Repositories/WorkoutRecordsRepository.swift
@@ -28,7 +28,14 @@ struct WorkoutRecordsRepository: WorkoutRecordsRepositoryRepresentable {
   private let provider: TNProvider<WorkoutRecordsRepositoryEndPoint>
   private let cacheManager = CacheManager.shared
   private let encoder = JSONEncoder()
-  private let decoder = JSONDecoder()
+  private let decoder: JSONDecoder = {
+    let jsonDecoder = JSONDecoder()
+    let dateFormatter = DateFormatter()
+    dateFormatter.locale = Locale(identifier: "ko_KR")
+    dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+    jsonDecoder.dateDecodingStrategy = .formatted(dateFormatter)
+    return jsonDecoder
+  }()
 
   init(session: URLSessionProtocol) {
     provider = .init(session: session)

--- a/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/CollectionViewCell/WorkoutInformationCollectionViewCell.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/CollectionViewCell/WorkoutInformationCollectionViewCell.swift
@@ -82,7 +82,8 @@ private extension WorkoutInformationCollectionViewCell {
     }
     contentView.addSubview(stackView)
     NSLayoutConstraint.activate([
-      stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+      stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Metrics.topBottomPadding),
+      stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: Metrics.topBottomPadding),
       stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Metrics.leadingTrailingpadding),
       stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Metrics.leadingTrailingpadding),
     ])

--- a/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/CollectionViewCell/WorkoutInformationCollectionViewCell.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/CollectionViewCell/WorkoutInformationCollectionViewCell.swift
@@ -75,6 +75,7 @@ final class WorkoutInformationCollectionViewCell: UICollectionViewCell {
 private extension WorkoutInformationCollectionViewCell {
   func configureUI() {
     contentView.backgroundColor = DesignSystemColor.gray01
+    contentView.layer.cornerRadius = 8
 
     [sportLabel, startTimeLabel, endTimeLabel, distanceLabel].forEach {
       stackView.addArrangedSubview($0)

--- a/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/CollectionViewCell/WorkoutInformationCollectionViewCell.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/CollectionViewCell/WorkoutInformationCollectionViewCell.swift
@@ -82,8 +82,7 @@ private extension WorkoutInformationCollectionViewCell {
     }
     contentView.addSubview(stackView)
     NSLayoutConstraint.activate([
-      stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Metrics.topBottomPadding),
-      stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: Metrics.topBottomPadding),
+      stackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
       stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Metrics.leadingTrailingpadding),
       stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Metrics.leadingTrailingpadding),
     ])
@@ -94,7 +93,7 @@ private extension WorkoutInformationCollectionViewCell {
 
 private enum Metrics {
   static let leadingTrailingpadding: CGFloat = 10
-  static let topBottomPadding: CGFloat = 47
+  static let topBottomPadding: CGFloat = 20
 }
 
 // MARK: - WorkoutInformation

--- a/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordContainerViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordContainerViewController.swift
@@ -84,6 +84,6 @@ private extension RecordContainerViewController {
 
 private enum Metrics {
   static let componentInterval: CGFloat = 24
-  static let bottomInterval: CGFloat = 215
+  static let bottomInterval: CGFloat = 160
   static let calendarHeight: CGFloat = 51
 }

--- a/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordListViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordListViewController.swift
@@ -55,6 +55,7 @@ final class RecordListViewController: UIViewController {
 
   private let noRecordsView: NoRecordsView = {
     let view = NoRecordsView()
+    view.layer.cornerRadius = 8
     view.translatesAutoresizingMaskIntoConstraints = false
     view.isHidden = true
     return view
@@ -190,15 +191,14 @@ private extension RecordListViewController {
     }
 
     workoutInformationDataSource = WorkoutInformationDataSource(
-      collectionView: workoutInformationCollectionView,
-      cellProvider: { collectionView, indexPath, itemIdentifier in
-        return collectionView.dequeueConfiguredReusableCell(
-          using: cellRegistration,
-          for: indexPath,
-          item: itemIdentifier
-        )
-      }
-    )
+      collectionView: workoutInformationCollectionView
+    ) { collectionView, indexPath, itemIdentifier in
+      return collectionView.dequeueConfiguredReusableCell(
+        using: cellRegistration,
+        for: indexPath,
+        item: itemIdentifier
+      )
+    }
   }
 
   func configureSnapShot(items: [WorkoutInformationItem]) {

--- a/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordListViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordListViewController.swift
@@ -26,7 +26,7 @@ final class RecordListViewController: UIViewController {
   private let todayLabel: UILabel = {
     let label = UILabel()
     label.translatesAutoresizingMaskIntoConstraints = false
-    label.text = "오늘\n ??월 ??일 ?요일"
+    label.text = "오늘\n??월 ??일 ?요일"
     label.numberOfLines = 0
     label.font = .preferredFont(forTextStyle: .title1, weight: .bold)
     label.textColor = DesignSystemColor.primaryText
@@ -122,7 +122,7 @@ private extension RecordListViewController {
       noRecordsView.isHidden = true
     case let .sucessDateInfo(dateInfo):
       guard let dayOfWeek = dateInfo.dayOfWeek else { return }
-      todayLabel.text = "지금\n \(dateInfo.month)월 \(dateInfo.date)일 \(dayOfWeek)요일"
+      todayLabel.text = "지금\n\(dateInfo.month)월 \(dateInfo.date)일 \(dayOfWeek)요일"
     case let .customError(error):
       if let recordListViewModelError = (error as? RecordListViewModelError), recordListViewModelError == .recordUpdateFail {
         workoutInformationCollectionView.isHidden = true


### PR DESCRIPTION
## Screenshots 📸

|iPhone SE 2nd generation|
|:-:|
|<img src="https://github.com/boostcampwm2023/iOS08-WeTri/assets/57972338/e5a448b2-60c5-497d-8a2d-df2f89f6701d" width="33%"/>|

## 고민, 과정, 근거 💬

- 기록 화면에서 기록을 가져오지 못하는 버그가 있었고, 서버의 API와 클라이언트에서 설정한 API 모델이 달라 발생한 문제였습니다.
- 서버의 데이터 응답 모델을 맞추고, Mock json도 업데이트했습니다.
- 코드를 약간 다듬었습니다.

<br/><br/>

---

- Closed: #375
