### PR TITLE
[GWL-388] 매칭 될 때 실제 매칭되는 화면처럼 수정

### DIFF
--- a/iOS/Projects/Features/Record/Sources/Presentation/WorkoutPeerMatchingScene/ViewController/WorkoutPeerRandomMatchingViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/WorkoutPeerMatchingScene/ViewController/WorkoutPeerRandomMatchingViewController.swift
@@ -24,11 +24,13 @@ final class WorkoutPeerRandomMatchingViewController: UIViewController {
 
   private var subscriptions: Set<AnyCancellable> = []
 
+  private var matchingDescriptionLabelQueue: [String] = []
+
   // MARK: UI Components
 
   private let matchingDescriptionLabel: UILabel = {
     let label = UILabel()
-    label.text = "초기 값 입니다."
+    label.text = "대전 상대를 검색중입니다."
     label.font = .preferredFont(forTextStyle: .largeTitle, weight: .bold)
     label.contentMode = .scaleAspectFit
     label.numberOfLines = 1
@@ -91,6 +93,7 @@ private extension WorkoutPeerRandomMatchingViewController {
     setupHierarchyAndConstraints()
     bind()
     didTapCancelButton()
+    bindMatchingDescriptionLabel()
   }
 
   func setupStyles() {
@@ -138,6 +141,22 @@ private extension WorkoutPeerRandomMatchingViewController {
       .bind(to: cancelButtonDidTapPublisher)
       .store(in: &subscriptions)
   }
+
+  func bindMatchingDescriptionLabel() {
+    matchingDescriptionLabelQueue = Constants.initTextList
+
+    Timer.publish(every: 0.4, on: RunLoop.main, in: .common)
+      .autoconnect()
+      .subscribe(on: RunLoop.main)
+      .sink { [weak self] _ in
+        guard let text = self?.matchingDescriptionLabelQueue.removeFirst() else {
+          return
+        }
+        self?.matchingDescriptionLabel.text = text
+        self?.matchingDescriptionLabelQueue.append(text)
+      }
+      .store(in: &subscriptions)
+  }
 }
 
 // MARK: WorkoutPeerRandomMatchingViewController.Metrics
@@ -146,5 +165,13 @@ private extension WorkoutPeerRandomMatchingViewController {
   enum Metrics {
     static let labelTopConstraints: CGFloat = 222
     static let componentSpacing: CGFloat = 30
+  }
+
+  enum Constants {
+    static let initTextList: [String] = [
+      "대전 상대를 검색중입니다.",
+      "대전 상대를 검색중입니다..",
+      "대전 상대를 검색중입니다...",
+    ]
   }
 }


### PR DESCRIPTION
## Screenshots 📸

|매칭되는 화면 수정|
|:-:|
|![Simulator Screen Recording - iPhone 15 Pro - 2023-12-12 at 00 17 35](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/5d57e783-f029-4882-88eb-b3fb8c4fd456)|

<br/><br/>

## 고민, 과정, 근거 💬

### Queue를 활용하여 Text를 가져왔습니다.
- removeFIrst가 O(n) 이지만 n = 3 이고, data가 String 이라 무시해도 될 것이라 생각했습니다.

<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #388
