### PR TITLE
[GWL-306] 닉네임 중복검사 기능 추가

### DIFF
--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -6,9 +6,6 @@
 //  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
 //
 
-import LoginFeature
-import RecordFeature
-import SignUpFeature
 import UIKit
 
 import DesignSystem
@@ -22,9 +19,8 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     window = UIWindow(windowScene: windowScene)
     let navigationController = UINavigationController()
     window?.rootViewController = navigationController
-    let coordinator = SignUpFeatureCoordinator(navigationController: navigationController, newUserInformation: NewUserInformation(mappedUserID: "", provider: .apple), isMockEnvironment: false)
-//    let coordinator = RecordFeatureCoordinator(navigationController: navigationController, isMockEnvironment: true)
-//    coordinating = coordinator
+    let coordinator = AppCoordinator(navigationController: navigationController)
+    coordinating = coordinator
     coordinator.start()
     window?.makeKeyAndVisible()
   }

--- a/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
+++ b/iOS/Projects/App/WeTri/Sources/Application/SceneDelegate.swift
@@ -22,8 +22,9 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     window = UIWindow(windowScene: windowScene)
     let navigationController = UINavigationController()
     window?.rootViewController = navigationController
-    let coordinator = AppCoordinator(navigationController: navigationController)
-    coordinating = coordinator
+    let coordinator = SignUpFeatureCoordinator(navigationController: navigationController, newUserInformation: NewUserInformation(mappedUserID: "", provider: .apple), isMockEnvironment: false)
+//    let coordinator = RecordFeatureCoordinator(navigationController: navigationController, isMockEnvironment: true)
+//    coordinating = coordinator
     coordinator.start()
     window?.makeKeyAndVisible()
   }

--- a/iOS/Projects/Features/SignUp/Sources/Data/DTO/NickNameDuplicateRequestDTO.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Data/DTO/NickNameDuplicateRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  NickNameDuplicateRequestDTO.swift
+//  SignUpFeature
+//
+//  Created by 안종표 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+struct NickNameDuplicateRequestDTO: Codable {
+  let nickname: String
+}

--- a/iOS/Projects/Features/SignUp/Sources/Data/Repository/SignUpRepository.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Data/Repository/SignUpRepository.swift
@@ -42,23 +42,57 @@ public struct SignUpRepository: SignUpRepositoryRepresentable {
     .compactMap(\.data)
     .eraseToAnyPublisher()
   }
+
+  public func duplicateTest(nickName: String) -> AnyPublisher<Bool, Never> {
+    return Future<Bool, Never> { promise in
+      Task {
+        do {
+          let (_, response) = try await provider.requestResponse(.duplicate(NickNameDuplicateRequestDTO(nickname: nickName)))
+          guard let httpResponse = response as? HTTPURLResponse else {
+            return promise(.success(false))
+          }
+          switch httpResponse.statusCode {
+          // 중복이 아닌 경우
+          case 201:
+            return promise(.success(false))
+          // 중복인 경우
+          case 202:
+            return promise(.success(true))
+          default:
+            return promise(.success(false))
+          }
+        } catch {
+          Log.make().error("\(error)")
+        }
+      }
+    }
+    .map { result in
+      return result
+    }
+    .eraseToAnyPublisher()
+  }
 }
 
 // MARK: - SignUpRepositoryEndPoint
 
 private enum SignUpRepositoryEndPoint: TNEndPoint {
   case signup(SignUpUser)
+  case duplicate(NickNameDuplicateRequestDTO)
 
   var path: String {
     switch self {
     case .signup:
       return "/api/v1/auth/signup"
+    case .duplicate:
+      return "/api/v1/profiles/nickname-availability"
     }
   }
 
   var method: TNMethod {
     switch self {
     case .signup:
+      return .post
+    case .duplicate:
       return .post
     }
   }
@@ -71,6 +105,8 @@ private enum SignUpRepositoryEndPoint: TNEndPoint {
     switch self {
     case let .signup(signUpUser):
       return signUpUser
+    case let .duplicate(nickName):
+      return nickName
     }
   }
 

--- a/iOS/Projects/Features/SignUp/Sources/Domain/Interfaces/SignUpRepositoryRepresentable.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Domain/Interfaces/SignUpRepositoryRepresentable.swift
@@ -12,4 +12,5 @@ import Foundation
 
 public protocol SignUpRepositoryRepresentable {
   func signUp(signUpUser: SignUpUser) -> AnyPublisher<Token, Error>
+  func duplicateTest(nickName: String) -> AnyPublisher<Bool, Never>
 }

--- a/iOS/Projects/Features/SignUp/Sources/Domain/UseCase/SignUpUseCase.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Domain/UseCase/SignUpUseCase.swift
@@ -15,6 +15,7 @@ import Foundation
 
 public protocol SignUpUseCaseRepresentable {
   func signUp(signUpUser: SignUpUser) -> AnyPublisher<Token, Error>
+  func duplicateTest(with nickName: String) -> AnyPublisher<Bool, Never>
   func accessTokenSave(_ token: String)
   func refreshTokenSave(_ token: String)
 }
@@ -35,6 +36,11 @@ public final class SignUpUseCase: SignUpUseCaseRepresentable {
 
   public func signUp(signUpUser: SignUpUser) -> AnyPublisher<Token, Error> {
     return signUpRepository.signUp(signUpUser: signUpUser)
+      .eraseToAnyPublisher()
+  }
+
+  public func duplicateTest(with nickName: String) -> AnyPublisher<Bool, Never> {
+    return signUpRepository.duplicateTest(nickName: nickName)
       .eraseToAnyPublisher()
   }
 

--- a/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/SignUpProfileViewController.swift
@@ -59,7 +59,7 @@ public final class SignUpProfileViewController: UIViewController {
     return button
   }()
 
-  private let imageCheckerView: ImageCheckerView = {
+  private let imageCheckerView: CheckerView = {
     let view = ImageCheckerView(frame: .zero)
     view.translatesAutoresizingMaskIntoConstraints = false
     return view
@@ -84,6 +84,13 @@ public final class SignUpProfileViewController: UIViewController {
     let view = NickNameCheckerView(frame: .zero)
     view.translatesAutoresizingMaskIntoConstraints = false
     view.isHidden = true
+    return view
+  }()
+
+  private let nickNameDuplicatingCheckerView: CheckerView = {
+    let view = NickNameDuplicatingCheckerView()
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.configureEnabled()
     return view
   }()
 
@@ -154,6 +161,13 @@ private extension SignUpProfileViewController {
       nickNameCheckerView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
       nickNameCheckerView.topAnchor.constraint(equalTo: nickNameBoxView.bottomAnchor, constant: Metrics.componentInterval),
       nickNameCheckerView.widthAnchor.constraint(equalToConstant: Metrics.checkerWidth),
+    ])
+
+    view.addSubview(nickNameDuplicatingCheckerView)
+    NSLayoutConstraint.activate([
+      nickNameDuplicatingCheckerView.topAnchor.constraint(equalTo: nickNameCheckerView.bottomAnchor, constant: Metrics.checkerInteval),
+      nickNameDuplicatingCheckerView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor, constant: Metrics.safeAreaInterval),
+      nickNameDuplicatingCheckerView.widthAnchor.constraint(equalToConstant: Metrics.checkerWidth),
     ])
 
     view.addSubview(completionButton)
@@ -255,6 +269,16 @@ private extension SignUpProfileViewController {
           showAlert(message: "다시 시도 해주세요.")
         }
       }
+
+      if let profileViewModelError = error as? SignUpProfileViewModelError {
+        switch profileViewModelError {
+        case .duplicateNickName:
+          nickNameDuplicatingCheckerView.configureDisabled()
+        default:
+          nickNameDuplicatingCheckerView.configureEnabled()
+        }
+      }
+
     case .image:
       imageCheckerView.configureEnabled()
     }
@@ -436,4 +460,5 @@ private enum Metrics {
   static let buttonHeight: CGFloat = 44
   static let buttonSafeAreaInterval: CGFloat = 30
   static let checkerComponentInterval: CGFloat = 21
+  static let checkerInteval: CGFloat = 21
 }

--- a/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/View/NickNameDuplicatingCheckerView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/View/NickNameDuplicatingCheckerView.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 final class NickNameDuplicatingCheckerView: CheckerView {
-  override init(frame _: CGRect) {
-    super.init(frame: .zero)
+  override init(frame: CGRect) {
+    super.init(frame: frame)
   }
 
   override func configureEnabled() {

--- a/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/View/NickNameDuplicatingCheckerView.swift
+++ b/iOS/Projects/Features/SignUp/Sources/Presentation/SignUpProfileScene/View/NickNameDuplicatingCheckerView.swift
@@ -1,0 +1,25 @@
+//
+//  NickNameDuplicatingCheckerView.swift
+//  SignUpFeature
+//
+//  Created by 안종표 on 12/11/23.
+//  Copyright © 2023 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Foundation
+
+final class NickNameDuplicatingCheckerView: CheckerView {
+  override init(frame _: CGRect) {
+    super.init(frame: .zero)
+  }
+
+  override func configureEnabled() {
+    super.configureEnabled()
+    label.text = "닉네임이 중복되지 않았습니다."
+  }
+
+  override func configureDisabled() {
+    super.configureDisabled()
+    label.text = "닉네임이 중복되었습니다."
+  }
+}


### PR DESCRIPTION
## Screenshots 📸

|결과 화면|
|:-:|
|<img src="https://github.com/JongPyoAhn/Python/assets/68585628/9cf85964-5abc-4a0a-a719-44b11d860492" width="300" height="500">|
<br/><br/>

## 고민, 과정, 근거 💬
### 닉네임 중복체크를 어떤방식으로 하면 좋을까?
중복체크 버튼을 이용하는 방식과 닉네임을 입력할 때 특정조건이 만족하면 닉네임 중복체크를 확인하는 방법이 있었습니다.
후자를 선택했는데요. Combine에는 Debounce라는 좋은 기능이 있기 때문입니다.
Debounce는 입력이 종료되고나서 설정한 시간후에 마지막으로 들어온 스트림을 실행시켜줍니다.


<br/><br/>

## References 📋
❌

<br/><br/>

---

- Closed: #(issue-here)
