### PR TITLE
[GWL- 393 (HotFix)] 온보딩 화면 텍스트 희미한 문제 해결

### DIFF
--- a/iOS/Projects/Features/Onboarding/Sources/Presentaion/ViweController/OnboardingViewController.swift
+++ b/iOS/Projects/Features/Onboarding/Sources/Presentaion/ViweController/OnboardingViewController.swift
@@ -162,7 +162,7 @@ private extension OnboardingViewController {
   }
 
   func setupStyles() {
-    view.backgroundColor = .white
+    view.backgroundColor = DesignSystemColor.primaryBackground
   }
 
   func bind() {

--- a/iOS/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Main-03.colorset/Contents.json
+++ b/iOS/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Main-03.colorset/Contents.json
@@ -24,8 +24,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0xB5",
-          "green" : "0x3F",
-          "red" : "0x51"
+          "green" : "0x51",
+          "red" : "0x3F"
         }
       },
       "idiom" : "universal"

--- a/iOS/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Main-03.colorset/Contents.json
+++ b/iOS/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Main-03.colorset/Contents.json
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.800",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFF"
+          "alpha" : "1.000",
+          "blue" : "0xB5",
+          "green" : "0x3F",
+          "red" : "0x51"
         }
       },
       "idiom" : "universal"

--- a/iOS/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Main-03.colorset/Contents.json
+++ b/iOS/Projects/Shared/DesignSystem/Resources/Colors.xcassets/Main-03.colorset/Contents.json
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0xB5",
-          "green" : "0x51",
-          "red" : "0x3F"
+          "alpha" : "0.800",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
         }
       },
       "idiom" : "universal"

--- a/iOS/Projects/Shared/DesignSystem/Sources/UIButtonConfiguration+Main.swift
+++ b/iOS/Projects/Shared/DesignSystem/Sources/UIButtonConfiguration+Main.swift
@@ -22,7 +22,7 @@ public extension UIButton.Configuration {
     plainConfiguration.background = backgroundConfiguration
 
     plainConfiguration.titleAlignment = .center
-    plainConfiguration.baseForegroundColor = DesignSystemColor.secondaryBackground
+    plainConfiguration.baseForegroundColor = .white
     plainConfiguration.title = title
 
     return plainConfiguration

--- a/iOS/Projects/Shared/DesignSystem/Sources/UIButtonConfiguration+MainCircular.swift
+++ b/iOS/Projects/Shared/DesignSystem/Sources/UIButtonConfiguration+MainCircular.swift
@@ -22,9 +22,8 @@ public extension UIButton.Configuration {
 
     plainConfiguration.titleAlignment = .center
     plainConfiguration.cornerStyle = .capsule
-    plainConfiguration.baseForegroundColor = DesignSystemColor.secondaryBackground
+    plainConfiguration.baseForegroundColor = .white
     plainConfiguration.title = title
-    plainConfiguration.attributedTitle?.foregroundColor = DesignSystemColor.primaryText
 
     return plainConfiguration
   }
@@ -40,7 +39,6 @@ public extension UIButton.Configuration {
     plainConfiguration.cornerStyle = .capsule
     plainConfiguration.baseForegroundColor = DesignSystemColor.secondaryBackground
     plainConfiguration.title = title
-    plainConfiguration.attributedTitle?.foregroundColor = DesignSystemColor.primaryText
 
     return plainConfiguration
   }

--- a/iOS/Projects/Shared/DesignSystem/Sources/UIButtonConfiguration+MainCircular.swift
+++ b/iOS/Projects/Shared/DesignSystem/Sources/UIButtonConfiguration+MainCircular.swift
@@ -24,6 +24,7 @@ public extension UIButton.Configuration {
     plainConfiguration.cornerStyle = .capsule
     plainConfiguration.baseForegroundColor = DesignSystemColor.secondaryBackground
     plainConfiguration.title = title
+    plainConfiguration.attributedTitle?.foregroundColor = DesignSystemColor.primaryText
 
     return plainConfiguration
   }
@@ -39,6 +40,7 @@ public extension UIButton.Configuration {
     plainConfiguration.cornerStyle = .capsule
     plainConfiguration.baseForegroundColor = DesignSystemColor.secondaryBackground
     plainConfiguration.title = title
+    plainConfiguration.attributedTitle?.foregroundColor = DesignSystemColor.primaryText
 
     return plainConfiguration
   }


### PR DESCRIPTION
## Screenshots 📸

 온보딩 화면일 때 텍스들이 희미하게 보이는 버그를 수정했습니다. 
|Name|
|:-:|
|![image](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/3c736004-1cd3-4bbc-92eb-bd88eab9726c)|

<br/><br/>

## 고민, 과정, 근거 💬

<br/><br/>

## References 📋


<br/><br/>

---

- Closed: #393
