### PR TITLE
[GWL-396] 시간대 15시간 차이나는 버그 수정

### DIFF
--- a/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
+++ b/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
@@ -49,6 +49,7 @@ extension Record {
     let startDate = endDate - Double(workoutTime)
     let formatter = DateFormatter()
     formatter.dateFormat = "HH:mm:ss"
+    formatter.timeZone = .init(abbreviation: "UTC")
 
     // 날짜를 문자열로 변환
     let startDateString = formatter.string(from: startDate)

--- a/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
+++ b/iOS/Projects/Features/Record/Sources/Data/DTO/RecordResponseDTO.swift
@@ -45,48 +45,15 @@ extension Record {
   }
 
   private static func timeToTime(createdAt: Date, workoutTime: Int) -> (startTime: String, endTime: String)? {
-    let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: createdAt)
+    let endDate = createdAt
+    let startDate = endDate - Double(workoutTime)
+    let formatter = DateFormatter()
+    formatter.dateFormat = "HH:mm:ss"
 
-    guard
-      let hour = dateComponents.hour,
-      let minute = dateComponents.minute,
-      let second = dateComponents.second
-    else {
-      return nil
-    }
+    // 날짜를 문자열로 변환
+    let startDateString = formatter.string(from: startDate)
+    let endDateString = formatter.string(from: endDate)
 
-    let startSeconds = Time(hour: hour, minute: minute, second: second).toSeconds()
-    let endSeconds = startSeconds + workoutTime
-    let start = prettyStyle(time: timeToHourMinuteSecond(seconds: startSeconds))
-    let end = prettyStyle(time: timeToHourMinuteSecond(seconds: endSeconds))
-    return (start, end)
-  }
-
-  private static func timeToHourMinuteSecond(seconds: Int) -> Time {
-    var seconds = seconds
-    let hour = seconds / 3600
-    seconds %= 3600
-    let minute = seconds / 60
-    seconds %= 60
-    return Time(hour: hour, minute: minute, second: seconds)
-  }
-
-  private static func prettyStyle(time: Time) -> String {
-    let formattedHour = String(format: "%02d", time.hour)
-    let formattedMinute = String(format: "%02d", time.minute)
-    let formattedSecond = String(format: "%02d", time.second)
-    return "\(formattedHour):\(formattedMinute):\(formattedSecond)"
-  }
-}
-
-// MARK: - Time
-
-private struct Time {
-  let hour: Int
-  let minute: Int
-  let second: Int
-
-  func toSeconds() -> Int {
-    return hour * 3600 + minute * 60 + second
+    return (startDateString, endDateString)
   }
 }

--- a/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordListViewController.swift
+++ b/iOS/Projects/Features/Record/Sources/Presentation/RecordScene/ViewController/RecordListViewController.swift
@@ -114,7 +114,7 @@ private extension RecordListViewController {
           sport: $0.mode.description,
           startTime: $0.startTime,
           endTime: $0.endTime,
-          distance: "\($0.distance)km"
+          distance: "\($0.distance)m"
         )
       }
       configureSnapShot(items: workoutInformationItems)


### PR DESCRIPTION
## 고민, 과정, 근거 💬

- km를 `m`로 수정
- 시간대가 15시간 차이나는 이슈 수정
   - 서버로부터 데이터를 받아올 때 `Date`타입의 TimeZone이 UTC로 처리되는 이슈가 존재했고,
     dateFormatter의 TimeZone을 `UTC`로 설정해서 같은 시간대로 String파싱이 가능하도록 설정함


---

- Closed: #396
