### PR TITLE
[GWL-445] CombineCocoa GesturePublisher 생성

### DIFF
--- a/iOS/Projects/Shared/CombineCocoa/Sources/GestureSubscription.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Sources/GestureSubscription.swift
@@ -1,0 +1,38 @@
+//
+//  GestureSubscription.swift
+//  CombineCocoa
+//
+//  Created by MaraMincho on 1/11/24.
+//  Copyright © 2024 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+final class GestureSubscription<T: Subscriber>: Subscription where T.Input == UIGestureRecognizer, T.Failure == Never {
+  var subscriber: T?
+  let gesture: UIGestureRecognizer
+  var targetView: UIView?
+
+  @objc func action() {
+    _ = subscriber?.receive(gesture)
+  }
+
+  init(subscriber: T, gesture: UIGestureRecognizer, targetView: UIView) {
+    self.subscriber = subscriber
+    self.gesture = gesture
+    self.targetView = targetView
+
+    gesture.addTarget(self, action: #selector(action))
+    targetView.addGestureRecognizer(gesture)
+  }
+
+  func request(_: Subscribers.Demand) {}
+
+  func cancel() {
+    gesture.removeTarget(self, action: #selector(action))
+    targetView?.removeGestureRecognizer(gesture)
+    targetView = nil
+    subscriber = nil
+  }
+}

--- a/iOS/Projects/Shared/CombineCocoa/Sources/UIView+Publisher.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Sources/UIView+Publisher.swift
@@ -18,9 +18,10 @@ public extension UIView {
     public typealias Output = UIGestureRecognizer
     public typealias Failure = Never
 
-    let targetView: UIView
-    let gesture: UIGestureRecognizer
-    init(targetView: UIView, gesture: UIGestureRecognizer) {
+    private let targetView: UIView
+    private let gesture: UIGestureRecognizer
+
+    public init(targetView: UIView, gesture: UIGestureRecognizer) {
       self.targetView = targetView
       self.gesture = gesture
     }

--- a/iOS/Projects/Shared/CombineCocoa/Sources/UIView+Publisher.swift
+++ b/iOS/Projects/Shared/CombineCocoa/Sources/UIView+Publisher.swift
@@ -1,0 +1,59 @@
+//
+//  UIView+Publisher.swift
+//  CombineCocoa
+//
+//  Created by MaraMincho on 1/11/24.
+//  Copyright © 2024 kr.codesquad.boostcamp8. All rights reserved.
+//
+
+import Combine
+import UIKit
+
+public extension UIView {
+  func publisher(gesture: GestureType) -> GesturePublisher {
+    return GesturePublisher(targetView: self, gesture: gesture.recognizer)
+  }
+
+  struct GesturePublisher: Publisher {
+    public typealias Output = UIGestureRecognizer
+    public typealias Failure = Never
+
+    let targetView: UIView
+    let gesture: UIGestureRecognizer
+    init(targetView: UIView, gesture: UIGestureRecognizer) {
+      self.targetView = targetView
+      self.gesture = gesture
+    }
+
+    public func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, UIGestureRecognizer == S.Input {
+      let subscription = GestureSubscription(subscriber: subscriber, gesture: gesture, targetView: targetView)
+      subscriber.receive(subscription: subscription)
+    }
+  }
+
+  enum GestureType {
+    case tap
+    case swipe
+    case longPress
+    case pan
+    case pinch
+    case edge
+
+    var recognizer: UIGestureRecognizer {
+      switch self {
+      case .tap:
+        return UITapGestureRecognizer()
+      case .swipe:
+        return UISwipeGestureRecognizer()
+      case .longPress:
+        return UILongPressGestureRecognizer()
+      case .pan:
+        return UIPanGestureRecognizer()
+      case .pinch:
+        return UIPinchGestureRecognizer()
+      case .edge:
+        return UIPinchGestureRecognizer()
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Screenshots 📸

|로그|실제 코드|
|:-:|:-:|
|![스크린샷 2024-01-11 오후 2 16 19](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/de0a2de0-3493-4e41-a1d8-89444c2460e4)|![스크린샷 2024-01-11 오후 2 16 17](https://github.com/boostcampwm2023/iOS08-WeTri/assets/103064352/2d154aec-27c6-47d4-bbfa-c37f126f682e)|

<br/><br/>

## 고민, 과정, 근거 💬
### GesturePublisher를 어떻게 만들지?
- Event처럼 달고 싶은데 어떻게 하면 좋을지 고민.
- GestureSubscription에서 Subscriber를 받아서 gesture에 addTarget을 통해 Subscriber에게 이벤트를 전달하는 방식으로 만듦


### 추가로?
- 현재는 Gesture를 넘기는 것은 일차원적인 Gesture 밖에 없음.
- 만약 CustomGesture를 넘길려면 [레퍼런스](https://jllnmercier.medium.com/combine-handling-uikits-gestures-with-a-publisher-c9374de5a478) 같이 하면 되는데, 이렇게 하는 것에 메리트를 못 느껴서 다음과 같이 작성
- Test에 관해서 고민했지만, CombineComunity에 CombineCocoa 에도 Gesture에 관한 Test가 없었음... 
- 따라서 UnitTest를 통해서 접근해도 좋을 것 같다는 생각이 들었음(언젠간 하겠지...?)


<br/><br/>

## References 📋
- [GestureType](https://jllnmercier.medium.com/combine-handling-uikits-gestures-with-a-publisher-c9374de5a478)


<br/><br/>

---

- Closed: #445
